### PR TITLE
Feat: Prometheus 커스텀 메트릭 + alert threshold tuning

### DIFF
--- a/backend/api/routers/webhooks/payment.py
+++ b/backend/api/routers/webhooks/payment.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, HTTPException, Request
 
 from backend.common.audit import write_audit_log
 from backend.common.errors import ErrorCode, http_error
+from backend.common.metrics import PAYMENT_FAILURES
 from backend.db.queries.subscriptions import update_subscription_by_provider_id
 
 router = APIRouter(prefix="/webhooks", tags=["webhooks"])
@@ -96,6 +97,7 @@ async def payment_webhook(request: Request) -> dict:
     except HTTPException:
         raise
     except Exception as exc:
+        PAYMENT_FAILURES.inc()
         logger.error("payment_webhook_failed", error=str(exc))
         raise http_error(
             ErrorCode.INTERNAL_ERROR,

--- a/backend/common/metrics.py
+++ b/backend/common/metrics.py
@@ -1,0 +1,39 @@
+"""Custom Prometheus metrics for TrendScope monitoring. (Phase 10 alert threshold tuning)"""
+
+from __future__ import annotations
+
+from prometheus_client import Counter, Gauge
+
+# Cache hit/miss tracking
+CACHE_REQUESTS = Counter(
+    "cache_requests_total",
+    "Total cache requests",
+    ["result"],  # hit | miss
+)
+
+# Crawler success/failure tracking
+CRAWLER_REQUESTS = Counter(
+    "crawler_requests_total",
+    "Total crawler requests",
+    ["source", "result"],  # result: success | failure
+)
+
+# AI API call tracking
+AI_API_REQUESTS = Counter(
+    "ai_api_requests_total",
+    "Total AI API requests",
+    ["provider", "result"],  # result: success | failure
+)
+
+# Payment failure tracking
+PAYMENT_FAILURES = Counter(
+    "payment_failures_total",
+    "Total payment webhook failures",
+)
+
+# Source quota usage ratio (used / limit)
+SOURCE_QUOTA_RATIO = Gauge(
+    "source_quota_ratio",
+    "Source quota usage ratio (used / limit)",
+    ["source"],
+)

--- a/backend/crawler/quota_guard.py
+++ b/backend/crawler/quota_guard.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncpg
 import structlog
 
+from backend.common.metrics import SOURCE_QUOTA_RATIO
+
 logger = structlog.get_logger(__name__)
 
 
@@ -35,6 +37,8 @@ async def check_quota(source_name: str, db_pool: asyncpg.Pool) -> bool:
 
         if limit == 0:
             return True
+
+        SOURCE_QUOTA_RATIO.labels(source=source_name).set(used / limit)
 
         if used >= limit:
             logger.warning(

--- a/backend/crawler/sources/community_crawler.py
+++ b/backend/crawler/sources/community_crawler.py
@@ -12,6 +12,7 @@ import httpx
 import structlog
 from bs4 import BeautifulSoup
 
+from backend.common.metrics import CRAWLER_REQUESTS
 from backend.crawler.quota_guard import check_quota, increment_quota
 from backend.crawler.sources.robots import is_allowed
 from backend.crawler.sources.rss_feeds import COMMUNITY_FEEDS, FeedSource
@@ -54,9 +55,11 @@ async def crawl_dc_inside(db_pool: asyncpg.Pool) -> list[dict[str, Any]]:
                     logger.warning("dc_feed_error", feed=feed["name"], error=str(exc))
                     continue
 
+        CRAWLER_REQUESTS.labels(source="dc_inside", result="success").inc()
         logger.info("dc_inside_crawl_complete", total=len(articles))
         return articles
     except Exception as exc:
+        CRAWLER_REQUESTS.labels(source="dc_inside", result="failure").inc()
         logger.error("dc_inside_crawl_failed", error=str(exc))
         return []
 
@@ -86,9 +89,11 @@ async def crawl_fm_korea(db_pool: asyncpg.Pool) -> list[dict[str, Any]]:
                     logger.warning("fm_feed_error", feed=feed["name"], error=str(exc))
                     continue
 
+        CRAWLER_REQUESTS.labels(source="fm_korea", result="success").inc()
         logger.info("fm_korea_crawl_complete", total=len(articles))
         return articles
     except Exception as exc:
+        CRAWLER_REQUESTS.labels(source="fm_korea", result="failure").inc()
         logger.error("fm_korea_crawl_failed", error=str(exc))
         return []
 

--- a/backend/crawler/sources/news_crawler.py
+++ b/backend/crawler/sources/news_crawler.py
@@ -11,6 +11,7 @@ import feedparser
 import httpx
 import structlog
 
+from backend.common.metrics import CRAWLER_REQUESTS
 from backend.crawler.quota_guard import check_quota, increment_quota
 from backend.crawler.sources.extractor import extract_body
 from backend.crawler.sources.rss_feeds import ALL_NEWS_FEEDS, FeedSource
@@ -94,6 +95,7 @@ async def crawl_feed(
             db_pool,
             extract_bodies=extract_bodies,
         )
+        CRAWLER_REQUESTS.labels(source=feed["name"], result="success").inc()
         logger.info(
             "feed_crawled",
             feed=feed["name"],
@@ -103,6 +105,7 @@ async def crawl_feed(
         return articles
 
     except Exception as exc:
+        CRAWLER_REQUESTS.labels(source=feed.get("name", "unknown"), result="failure").inc()
         logger.error("feed_crawl_error", feed=feed.get("name", "?"), error=str(exc))
         return []
 

--- a/backend/processor/shared/ai_summarizer.py
+++ b/backend/processor/shared/ai_summarizer.py
@@ -9,6 +9,7 @@ import re
 
 import structlog
 
+from backend.common.metrics import AI_API_REQUESTS
 from backend.processor.shared.ai_config import AIConfig
 
 logger = structlog.get_logger(__name__)
@@ -36,10 +37,12 @@ async def summarize(text: str, prompt: str, config: AIConfig) -> tuple[str, bool
 
         if provider == "gemini":
             result = await _call_gemini(text, prompt, config)
+            AI_API_REQUESTS.labels(provider="gemini", result="success").inc()
             return (result, False)
 
         if provider == "openai":
             result = await _call_openai(text, prompt, config)
+            AI_API_REQUESTS.labels(provider="openai", result="success").inc()
             return (result, False)
 
         if provider == "textrank":
@@ -51,6 +54,7 @@ async def summarize(text: str, prompt: str, config: AIConfig) -> tuple[str, bool
         return (result, True)
 
     except Exception as exc:
+        AI_API_REQUESTS.labels(provider=config.provider, result="failure").inc()
         logger.warning(
             "ai_provider_failed",
             provider=config.provider,

--- a/backend/processor/shared/cache_manager.py
+++ b/backend/processor/shared/cache_manager.py
@@ -8,6 +8,8 @@ from collections.abc import Awaitable, Callable
 import redis.asyncio as aioredis
 import structlog
 
+from backend.common.metrics import CACHE_REQUESTS
+
 logger = structlog.get_logger(__name__)
 
 _redis_pool: aioredis.Redis | None = None
@@ -47,8 +49,10 @@ async def get_cached(key: str) -> bytes | None:
     """Return cached bytes for key, or None on miss / error."""
     try:
         value = await get_redis().get(key)
+        CACHE_REQUESTS.labels(result="hit" if value is not None else "miss").inc()
         return value
     except Exception as exc:
+        CACHE_REQUESTS.labels(result="miss").inc()
         logger.warning("cache_get_failed", key=key, error=str(exc))
         return None
 

--- a/infra/prometheus/alert.rules.yml
+++ b/infra/prometheus/alert.rules.yml
@@ -28,3 +28,48 @@ groups:
         annotations:
           summary: "Memory usage > 80%"
           description: "Memory usage is {{ $value }}%"
+
+      - alert: LowCacheHitRate
+        expr: rate(cache_requests_total{result="hit"}[5m]) / rate(cache_requests_total[5m]) < 0.7
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Cache hit rate < 70%"
+          description: "Cache hit rate is {{ $value | humanizePercentage }}"
+
+      - alert: HighCrawlerFailureRate
+        expr: rate(crawler_requests_total{result="failure"}[5m]) / rate(crawler_requests_total[5m]) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Crawler failure rate > 5%"
+          description: "Crawler failure rate is {{ $value | humanizePercentage }}"
+
+      - alert: LowAIAPISuccessRate
+        expr: rate(ai_api_requests_total{result="success"}[5m]) / rate(ai_api_requests_total[5m]) < 0.8
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "AI API success rate < 80%"
+          description: "AI API success rate is {{ $value | humanizePercentage }}"
+
+      - alert: ConsecutivePaymentFailures
+        expr: increase(payment_failures_total[10m]) >= 3
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: "3+ payment failures in 10 minutes"
+          description: "Payment failures: {{ $value }} in last 10 minutes"
+
+      - alert: HighSourceQuotaUsage
+        expr: source_quota_ratio > 0.9
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Source quota usage > 90%"
+          description: "Source {{ $labels.source }} quota ratio is {{ $value }}"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,113 @@
+"""Tests for custom Prometheus metrics instrumentation."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from backend.common.metrics import (
+    AI_API_REQUESTS,
+    CACHE_REQUESTS,
+    CRAWLER_REQUESTS,
+    PAYMENT_FAILURES,
+    SOURCE_QUOTA_RATIO,
+)
+
+
+class TestCacheMetrics:
+    """Cache hit/miss metric tests."""
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_increments_metric(self) -> None:
+        from backend.processor.shared.cache_manager import get_cached
+
+        before = CACHE_REQUESTS.labels(result="hit")._value.get()
+        with patch("backend.processor.shared.cache_manager.get_redis") as mock_redis:
+            mock_redis.return_value.get = AsyncMock(return_value=b"data")
+            await get_cached("test_key")
+        after = CACHE_REQUESTS.labels(result="hit")._value.get()
+        assert after == before + 1
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_increments_metric(self) -> None:
+        from backend.processor.shared.cache_manager import get_cached
+
+        before = CACHE_REQUESTS.labels(result="miss")._value.get()
+        with patch("backend.processor.shared.cache_manager.get_redis") as mock_redis:
+            mock_redis.return_value.get = AsyncMock(return_value=None)
+            await get_cached("missing_key")
+        after = CACHE_REQUESTS.labels(result="miss")._value.get()
+        assert after == before + 1
+
+    @pytest.mark.asyncio
+    async def test_cache_error_increments_miss(self) -> None:
+        from backend.processor.shared.cache_manager import get_cached
+
+        before = CACHE_REQUESTS.labels(result="miss")._value.get()
+        with patch("backend.processor.shared.cache_manager.get_redis") as mock_redis:
+            mock_redis.return_value.get = AsyncMock(side_effect=Exception("conn error"))
+            await get_cached("error_key")
+        after = CACHE_REQUESTS.labels(result="miss")._value.get()
+        assert after == before + 1
+
+
+class TestCrawlerMetrics:
+    """Crawler success/failure metric tests."""
+
+    def test_crawler_counter_labels(self) -> None:
+        before = CRAWLER_REQUESTS.labels(source="test_src", result="success")._value.get()
+        CRAWLER_REQUESTS.labels(source="test_src", result="success").inc()
+        after = CRAWLER_REQUESTS.labels(source="test_src", result="success")._value.get()
+        assert after == before + 1
+
+    def test_crawler_failure_counter(self) -> None:
+        before = CRAWLER_REQUESTS.labels(source="test_src", result="failure")._value.get()
+        CRAWLER_REQUESTS.labels(source="test_src", result="failure").inc()
+        after = CRAWLER_REQUESTS.labels(source="test_src", result="failure")._value.get()
+        assert after == before + 1
+
+
+class TestAIAPIMetrics:
+    """AI API request metric tests."""
+
+    def test_ai_api_success_counter(self) -> None:
+        before = AI_API_REQUESTS.labels(provider="gemini", result="success")._value.get()
+        AI_API_REQUESTS.labels(provider="gemini", result="success").inc()
+        after = AI_API_REQUESTS.labels(provider="gemini", result="success")._value.get()
+        assert after == before + 1
+
+    def test_ai_api_failure_counter(self) -> None:
+        before = AI_API_REQUESTS.labels(provider="openai", result="failure")._value.get()
+        AI_API_REQUESTS.labels(provider="openai", result="failure").inc()
+        after = AI_API_REQUESTS.labels(provider="openai", result="failure")._value.get()
+        assert after == before + 1
+
+
+class TestPaymentMetrics:
+    """Payment failure metric tests."""
+
+    def test_payment_failure_counter(self) -> None:
+        before = PAYMENT_FAILURES._value.get()
+        PAYMENT_FAILURES.inc()
+        after = PAYMENT_FAILURES._value.get()
+        assert after == before + 1
+
+
+class TestQuotaMetrics:
+    """Source quota ratio metric tests."""
+
+    def test_quota_ratio_gauge(self) -> None:
+        SOURCE_QUOTA_RATIO.labels(source="rss_ko").set(0.85)
+        assert SOURCE_QUOTA_RATIO.labels(source="rss_ko")._value.get() == 0.85
+
+    @pytest.mark.asyncio
+    async def test_check_quota_sets_ratio(self) -> None:
+        from backend.crawler.quota_guard import check_quota
+
+        mock_pool = AsyncMock()
+        mock_pool.fetchrow = AsyncMock(
+            return_value={"is_active": True, "quota_limit": 100, "quota_used": 75}
+        )
+        result = await check_quota("test_source", mock_pool)
+        assert result is True
+        assert SOURCE_QUOTA_RATIO.labels(source="test_source")._value.get() == 0.75


### PR DESCRIPTION
## Summary
- `backend/common/metrics.py` 신규: cache/crawler/AI API/payment/quota Prometheus Counter/Gauge 정의
- 6개 모듈에 메트릭 계측 코드 삽입 (cache_manager, news_crawler, community_crawler, ai_summarizer, payment, quota_guard)
- `alert.rules.yml`에 5개 알림 규칙 추가 → monitoring.md 8개 임계값 전체 커버
- `tests/test_metrics.py` 10개 테스트 추가

## Alert Rules 추가 목록
| Alert | 임계값 | Severity |
|---|---|---|
| LowCacheHitRate | < 70% (5m) | warning |
| HighCrawlerFailureRate | > 5% (5m) | warning |
| LowAIAPISuccessRate | < 80% (5m) | critical |
| ConsecutivePaymentFailures | ≥3 in 10m | critical |
| HighSourceQuotaUsage | > 90% (2m) | warning |

## Test plan
- [x] pytest 726 passed, coverage 78%
- [x] ruff lint + format passed
- [x] YAML syntax 검증 통과
- [x] secret scan passed

Closes: #39