### PR TITLE
Chore: Docker entrypoint 마이그레이션 자동 실행

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,6 +17,9 @@ WORKDIR /app
 # Layer cache: deps first, then source
 COPY --from=builder /install /usr/local
 COPY backend/ ./backend/
+COPY migrations/ ./migrations/
+COPY backend/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
@@ -29,4 +32,5 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"
 
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["uvicorn", "backend.api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+echo "[entrypoint] Running migrations..."
+python -m migrations.runner
+echo "[entrypoint] Migrations complete. Starting server..."
+
+exec "$@"


### PR DESCRIPTION
## Summary
- `backend/entrypoint.sh` 추가: 컨테이너 시작 시 마이그레이션 자동 실행 후 서버 기동
- `Dockerfile` 수정: migrations/ COPY + ENTRYPOINT 설정
- `docker-compose up` 한 번으로 DB 준비 + 서버 기동 완료

## Test plan
- [ ] `docker-compose build api`
- [ ] `docker-compose up` → 로그에서 `[entrypoint] Running migrations...` 확인
- [ ] `curl http://localhost:8000/health` → 200 OK
- [ ] 재시작 시 마이그레이션 스킵 확인 (idempotent)

Closes: #49