### PR TITLE
Chore: Docker 이미지 경량화 — CUDA 의존성 제거

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,6 +3,8 @@ FROM python:3.11-slim AS builder
 WORKDIR /build
 
 COPY requirements.txt .
+RUN pip install --no-cache-dir --prefix=/install \
+    torch --index-url https://download.pytorch.org/whl/cpu
 RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ bcrypt==4.2.1
 email-validator==2.2.0
 pyotp>=2.9.0
 
-# Phase 2: Crawler & Pipeline
+# Crawler & Pipeline
 feedparser>=6.0.11
 apscheduler>=3.10.4
 newspaper3k>=0.2.8
@@ -22,7 +22,7 @@ readability-lxml>=0.8.1
 beautifulsoup4>=4.12.0
 lxml>=5.0.0
 
-# Phase 2: NLP & ML
+# NLP & ML
 soynlp>=0.0.493
 scikit-learn>=1.5.0
 xgboost>=2.0.0
@@ -34,5 +34,5 @@ pybloom-live>=4.0.0
 # Email
 aiosmtplib>=3.0.0
 
-# Phase 10: Observability
+# Observability
 prometheus-fastapi-instrumentator>=6.0.0


### PR DESCRIPTION
## Summary
- Dockerfile: torch CPU 전용 사전 설치로 NVIDIA CUDA 1GB+ 제거
- requirements.txt: phase 번호 주석 정리

## Test plan
- [ ] `docker-compose build api` — CUDA 없이 빌드 완료
- [ ] 이미지 크기 1GB+ 감소 확인
- [ ] `docker-compose up` → health check 정상