### PR TITLE
Feat: 데이터 파이프라인 가동 — 크롤러/프로세서 진입점 및 시드 데이터

### DIFF
--- a/backend/crawler/main.py
+++ b/backend/crawler/main.py
@@ -1,0 +1,62 @@
+"""Crawler service entry point — runs APScheduler with periodic feed crawling."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+
+import asyncpg
+import structlog
+
+from backend.crawler.scheduler import create_scheduler, start_scheduler, stop_scheduler
+from backend.crawler.sources.news_crawler import crawl_all as news_crawl_all
+from backend.processor.shared.cache_manager import close_redis, init_redis
+
+logger = structlog.get_logger(__name__)
+
+
+async def main() -> None:
+    """Boot crawler: connect DB, run initial crawl, then start scheduler loop."""
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        raise RuntimeError("DATABASE_URL not set")
+
+    redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+    await init_redis(redis_url)
+
+    db_pool = await asyncpg.create_pool(dsn=database_url, min_size=2, max_size=10)
+    logger.info("crawler_db_pool_created")
+
+    scheduler = create_scheduler(db_pool)
+    await start_scheduler(scheduler)
+
+    # 즉시 첫 뉴스 크롤링 1회 실행 (스케줄러 interval 대기 없이)
+    try:
+        articles = await news_crawl_all(db_pool)
+        logger.info("initial_news_crawl_done", new_articles=len(articles))
+    except Exception as exc:
+        logger.error("initial_news_crawl_failed", error=str(exc))
+
+    # graceful shutdown
+    stop_event = asyncio.Event()
+
+    def _handle_signal() -> None:
+        logger.info("crawler_shutdown_signal_received")
+        stop_event.set()
+
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, _handle_signal)
+
+    logger.info("crawler_running")
+    await stop_event.wait()
+
+    await stop_scheduler(scheduler)
+    await close_redis()
+    await db_pool.close()
+    logger.info("crawler_shutdown_complete")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/db/queries/feed_sources.py
+++ b/backend/db/queries/feed_sources.py
@@ -297,8 +297,8 @@ async def update_feed_health(
                         last_success_at = now(),
                         consecutive_failures = 0,
                         avg_latency_ms = CASE
-                            WHEN avg_latency_ms IS NULL THEN $2
-                            ELSE (avg_latency_ms * 0.7 + $2 * 0.3)
+                            WHEN avg_latency_ms IS NULL THEN $2::float8
+                            ELSE (avg_latency_ms * 0.7 + $2::float8 * 0.3)
                         END,
                         total_crawl_count = total_crawl_count + 1,
                         updated_at = now()
@@ -316,8 +316,8 @@ async def update_feed_health(
                         last_error_at = now(),
                         consecutive_failures = consecutive_failures + 1,
                         avg_latency_ms = CASE
-                            WHEN avg_latency_ms IS NULL THEN $3
-                            ELSE (avg_latency_ms * 0.7 + $3 * 0.3)
+                            WHEN avg_latency_ms IS NULL THEN $3::float8
+                            ELSE (avg_latency_ms * 0.7 + $3::float8 * 0.3)
                         END,
                         total_crawl_count = total_crawl_count + 1,
                         total_error_count = total_error_count + 1,

--- a/backend/processor/main.py
+++ b/backend/processor/main.py
@@ -1,0 +1,88 @@
+"""Processor service entry point — polls unprocessed articles and runs pipeline."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+from typing import Any
+
+import asyncpg
+import structlog
+
+from backend.processor.pipeline import process_articles
+from backend.processor.shared.cache_manager import close_redis, init_redis
+
+logger = structlog.get_logger(__name__)
+
+_POLL_INTERVAL = 30  # seconds
+_BATCH_SIZE = 200
+
+
+async def _fetch_unprocessed(db_pool: asyncpg.Pool) -> list[dict[str, Any]]:
+    """Fetch articles without a group_id (not yet processed)."""
+    rows = await db_pool.fetch(
+        """
+        SELECT id, url, url_hash, title, body, source, author,
+               publish_time, locale
+        FROM news_article
+        WHERE group_id IS NULL
+        ORDER BY publish_time DESC
+        LIMIT $1
+        """,
+        _BATCH_SIZE,
+    )
+    return [dict(r) for r in rows]
+
+
+async def _poll_loop(db_pool: asyncpg.Pool, stop_event: asyncio.Event) -> None:
+    """Continuously poll for unprocessed articles and run pipeline."""
+    while not stop_event.is_set():
+        try:
+            articles = await _fetch_unprocessed(db_pool)
+            if articles:
+                saved = await process_articles(articles, db_pool)
+                logger.info("processor_batch_done", input=len(articles), saved=saved)
+            else:
+                logger.debug("processor_no_articles")
+        except Exception as exc:
+            logger.error("processor_poll_error", error=str(exc))
+
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=_POLL_INTERVAL)
+        except TimeoutError:
+            pass
+
+
+async def main() -> None:
+    """Boot processor: connect DB, start polling loop."""
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        raise RuntimeError("DATABASE_URL not set")
+
+    redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+    await init_redis(redis_url)
+
+    db_pool = await asyncpg.create_pool(dsn=database_url, min_size=2, max_size=10)
+    logger.info("processor_db_pool_created")
+
+    stop_event = asyncio.Event()
+
+    def _handle_signal() -> None:
+        logger.info("processor_shutdown_signal_received")
+        stop_event.set()
+
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, _handle_signal)
+
+    logger.info("processor_running")
+    await _poll_loop(db_pool, stop_event)
+
+    await close_redis()
+    await db_pool.close()
+    logger.info("processor_shutdown_complete")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/migrations/014_seed_source_config.py
+++ b/migrations/014_seed_source_config.py
@@ -1,0 +1,132 @@
+"""014_seed_source_config — source_config 시드 데이터 + admin_settings 초기화."""
+
+from __future__ import annotations
+
+import asyncpg
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+VERSION = "014"
+DESCRIPTION = "Seed source_config, backfill feed_source.source_config_id, seed admin_settings"
+
+SOURCE_CONFIGS: list[dict[str, str | int]] = [
+    {"source_name": "rss_ko", "source_type": "rss", "quota_limit": 5000},
+    {"source_name": "rss_en", "source_type": "rss", "quota_limit": 3000},
+    {"source_name": "dc_inside", "source_type": "scraper", "quota_limit": 1000},
+    {"source_name": "fm_korea", "source_type": "scraper", "quota_limit": 1000},
+    {"source_name": "reddit", "source_type": "api", "quota_limit": 2000},
+    {"source_name": "nitter_rss", "source_type": "rss", "quota_limit": 500},
+]
+
+# feed_source.source_type → source_config.source_name 매핑
+BACKFILL_RULES: list[tuple[str, str, str | None]] = [
+    # (feed source_type, locale filter or None, source_config name)
+    ("rss", "ko", "rss_ko"),
+    ("rss", "en", "rss_en"),
+    ("google_trends", None, "rss_ko"),
+    ("community", None, "dc_inside"),  # DC + FM은 아래에서 분리
+    ("reddit", None, "reddit"),
+    ("nitter", None, "nitter_rss"),
+]
+
+
+async def up(conn: asyncpg.Connection) -> None:
+    """Seed source_config, backfill feed_source, seed admin_settings."""
+
+    # 1. source_config 시드
+    for cfg in SOURCE_CONFIGS:
+        await conn.execute(
+            """
+            INSERT INTO source_config (source_name, source_type, quota_limit)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (source_name) DO NOTHING
+            """,
+            cfg["source_name"],
+            cfg["source_type"],
+            cfg["quota_limit"],
+        )
+    logger.info("source_config_seeded", count=len(SOURCE_CONFIGS))
+
+    # 2. feed_source.source_config_id 소급 업데이트
+    # RSS feeds — locale 기반 분류
+    await conn.execute("""
+        UPDATE feed_source SET source_config_id = sc.id
+        FROM source_config sc
+        WHERE feed_source.source_type = 'rss'
+          AND feed_source.locale = 'ko'
+          AND sc.source_name = 'rss_ko'
+          AND feed_source.source_config_id IS NULL
+    """)
+    await conn.execute("""
+        UPDATE feed_source SET source_config_id = sc.id
+        FROM source_config sc
+        WHERE feed_source.source_type = 'rss'
+          AND feed_source.locale = 'en'
+          AND sc.source_name = 'rss_en'
+          AND feed_source.source_config_id IS NULL
+    """)
+    # Google Trends
+    await conn.execute("""
+        UPDATE feed_source SET source_config_id = sc.id
+        FROM source_config sc
+        WHERE feed_source.source_type = 'google_trends'
+          AND sc.source_name = 'rss_ko'
+          AND feed_source.source_config_id IS NULL
+    """)
+    # Community — DC Inside
+    await conn.execute("""
+        UPDATE feed_source SET source_config_id = sc.id
+        FROM source_config sc
+        WHERE feed_source.source_type = 'community'
+          AND feed_source.name LIKE 'DC %'
+          AND sc.source_name = 'dc_inside'
+          AND feed_source.source_config_id IS NULL
+    """)
+    # Community — FM Korea
+    await conn.execute("""
+        UPDATE feed_source SET source_config_id = sc.id
+        FROM source_config sc
+        WHERE feed_source.source_type = 'community'
+          AND feed_source.name LIKE 'FM Korea%'
+          AND sc.source_name = 'fm_korea'
+          AND feed_source.source_config_id IS NULL
+    """)
+    # Reddit
+    await conn.execute("""
+        UPDATE feed_source SET source_config_id = sc.id
+        FROM source_config sc
+        WHERE feed_source.source_type = 'reddit'
+          AND sc.source_name = 'reddit'
+          AND feed_source.source_config_id IS NULL
+    """)
+    # Nitter
+    await conn.execute("""
+        UPDATE feed_source SET source_config_id = sc.id
+        FROM source_config sc
+        WHERE feed_source.source_type = 'nitter'
+          AND sc.source_name = 'nitter_rss'
+          AND feed_source.source_config_id IS NULL
+    """)
+    logger.info("feed_source_config_ids_backfilled")
+
+    # 3. admin_settings 시드
+    from backend.db.seeds.admin_settings import SEEDS
+
+    await conn.executemany(
+        """
+        INSERT INTO admin_settings (key, value, default_value, description)
+        VALUES ($1, to_jsonb($2::text), to_jsonb($3::text), $4)
+        ON CONFLICT (key) DO NOTHING
+        """,
+        SEEDS,
+    )
+    logger.info("admin_settings_seeded", count=len(SEEDS))
+
+
+async def down(conn: asyncpg.Connection) -> None:
+    """Remove seeded source_config rows and clear backfilled IDs."""
+    await conn.execute("UPDATE feed_source SET source_config_id = NULL")
+    await conn.execute("DELETE FROM source_config")
+    await conn.execute("DELETE FROM admin_settings")
+    logger.info("seed_source_config_reverted")

--- a/migrations/runner.py
+++ b/migrations/runner.py
@@ -26,7 +26,7 @@ MIGRATIONS: List[str] = [
     "migrations.011_feed_sources",
     "migrations.012_seed_feed_sources",
     "migrations.013_api_quota_alert",
-
+    "migrations.014_seed_source_config",
 ]
 
 


### PR DESCRIPTION
## Summary
- 크롤러/프로세서 서비스 진입점 생성으로 전체 데이터 파이프라인 가동
- source_config + admin_settings 시드 데이터 투입
- Docker workers 프로필 정상 동작 확인

## 변경 내역
### 신규 파일
- `backend/crawler/main.py` — APScheduler 기반 크롤러 (시작 시 즉시 1회 크롤링 + 이후 주기적)
- `backend/processor/main.py` — 미처리 기사 30초 polling → 8단계 파이프라인 처리
- `migrations/014_seed_source_config.py` — source_config 6종 시드 + feed_source backfill + admin_settings 시드

### 버그 수정
- `backend/db/queries/feed_sources.py` — update_feed_health float8 캐스트 추가
- 크롤러/프로세서 Redis `init_redis()` 호출 추가

## Test plan
- [x] `docker compose --profile frontend --profile workers up --build -d` — 7개 서비스 모두 Up
- [x] 마이그레이션 014 적용: source_config 6건, admin_settings 8건
- [x] 크롤러: 2,211개 기사 수집 확인
- [x] 프로세서: 300개 트렌드 그룹 생성 확인
- [x] API `/api/v1/trends` → 20건 트렌드 반환
- [x] 브라우저 `http://localhost/trends` → 트렌드 피드 렌더링
- [x] pytest 781 passed, 75.78% coverage
Closes: #58