### PR TITLE
Fix: 인사이트 페이지 UUID→keyword 버그 수정

### DIFF
--- a/backend/api/routers/insights.py
+++ b/backend/api/routers/insights.py
@@ -1,7 +1,8 @@
-"""GET /api/v1/trends/{keyword}/insights — Pro+ plan-gated action insights."""
+"""GET /api/v1/trends/{group_id}/insights — Pro+ plan-gated action insights."""
 
 from __future__ import annotations
 
+import re
 import urllib.parse
 from datetime import datetime, timezone
 
@@ -22,8 +23,11 @@ from backend.auth.dependencies import CurrentUser, require_plan
 from backend.common.audit import write_audit_log
 from backend.common.errors import ErrorCode, error_response
 from backend.db.queries.insights import (
+    fetch_group_info,
     fetch_news_for_keyword,
+    fetch_news_for_keywords,
     fetch_sns_for_keyword,
+    fetch_sns_for_keywords,
     increment_insight_usage,
 )
 from backend.processor.algorithms.action_insight import ActionInsightEngine, SourceItem
@@ -31,6 +35,10 @@ from backend.processor.shared.ai_config import get_ai_config
 
 router = APIRouter(tags=["insights"])
 logger = structlog.get_logger(__name__)
+
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE
+)
 
 
 def _parse_content(
@@ -60,9 +68,9 @@ def _parse_content(
         return GeneralInsight(**{k: content_dict.get(k, []) for k in keys})
 
 
-@router.get("/trends/{keyword}/insights", response_model=InsightResponse)
+@router.get("/trends/{group_id}/insights", response_model=InsightResponse)
 async def get_trend_insights(
-    keyword: str,
+    group_id: str,
     request: Request,
     role: str = Query(default="general"),
     locale: str = Query(default="ko"),
@@ -70,9 +78,13 @@ async def get_trend_insights(
     _rate_limit: CurrentUser = Depends(rate_limit_check),  # noqa: B008
     _quota: CurrentUser = Depends(check_insight_quota),  # noqa: B008
 ) -> InsightResponse:
-    """Return AI-generated action insights for a keyword, gated to Pro+ users."""
+    """Return AI-generated action insights for a trend group or keyword.
+
+    Accepts either a UUID (news_group.id) or a keyword string.
+    When a UUID is given, resolves the group's title and keywords for source lookup.
+    """
     try:
-        decoded_keyword = urllib.parse.unquote(keyword)
+        decoded_input = urllib.parse.unquote(group_id)
 
         role = role if role in {"marketer", "creator", "owner", "general"} else current_user.role
 
@@ -80,8 +92,22 @@ async def get_trend_insights(
 
         ai_config = await get_ai_config(pool)
 
-        news_rows = await fetch_news_for_keyword(pool, decoded_keyword, limit=10)
-        sns_rows = await fetch_sns_for_keyword(pool, decoded_keyword, limit=20)
+        # Resolve keywords: UUID → look up group title/keywords, else use as keyword
+        if _UUID_RE.match(decoded_input):
+            group_info = await fetch_group_info(pool, decoded_input)
+            if not group_info:
+                return error_response(ErrorCode.NOT_FOUND, "Trend group not found", status_code=404)
+            resolved_keyword = group_info["title"]
+            search_keywords = list(group_info["keywords"] or [])
+            if resolved_keyword and resolved_keyword not in search_keywords:
+                search_keywords.insert(0, resolved_keyword)
+            # Use multi-keyword search for better results
+            news_rows = await fetch_news_for_keywords(pool, search_keywords, limit=10)
+            sns_rows = await fetch_sns_for_keywords(pool, search_keywords, limit=20)
+        else:
+            resolved_keyword = decoded_input
+            news_rows = await fetch_news_for_keyword(pool, decoded_input, limit=10)
+            sns_rows = await fetch_sns_for_keyword(pool, decoded_input, limit=20)
 
         sources: list[SourceItem] = []
         for row in news_rows:
@@ -104,7 +130,7 @@ async def get_trend_insights(
             )
 
         engine = ActionInsightEngine(pool, ai_config)
-        insight_req = InsightRequest(keyword=decoded_keyword, role=role, locale=locale)
+        insight_req = InsightRequest(keyword=resolved_keyword, role=role, locale=locale)
         result = await engine.generate(insight_req, sources)
 
         today_reset_at = datetime.now(timezone.utc).replace(
@@ -117,7 +143,7 @@ async def get_trend_insights(
                 user_id=current_user.user_id,
                 action="insight_generated",
                 target_type="keyword",
-                target_id=decoded_keyword,
+                target_id=resolved_keyword,
                 ip_address=request.client.host if request.client else None,
                 user_agent=request.headers.get("user-agent"),
                 detail={"role": role, "locale": locale, "cached": result["cached"]},
@@ -128,7 +154,7 @@ async def get_trend_insights(
         content_obj = _parse_content(role, result["content"])
 
         return InsightResponse(
-            keyword=decoded_keyword,
+            keyword=resolved_keyword,
             role=role,
             locale=locale,
             content=content_obj,
@@ -140,7 +166,7 @@ async def get_trend_insights(
     except Exception as exc:
         logger.error(
             "insight_generation_failed",
-            keyword=keyword,
+            group_id=group_id,
             role=role,
             user_id=getattr(current_user, "user_id", None),
             error=str(exc),

--- a/backend/db/queries/insights.py
+++ b/backend/db/queries/insights.py
@@ -10,6 +10,74 @@ import structlog
 logger = structlog.get_logger(__name__)
 
 
+async def fetch_group_info(
+    pool: asyncpg.Pool,
+    group_id: str,
+) -> asyncpg.Record | None:
+    """Fetch news_group title and keywords by group UUID."""
+    try:
+        query = """
+            SELECT title, keywords
+            FROM news_group
+            WHERE id = $1::uuid
+        """
+        async with pool.acquire() as conn:
+            return await conn.fetchrow(query, group_id)
+    except Exception as exc:
+        logger.error("fetch_group_info_failed", group_id=group_id, error=str(exc))
+        raise
+
+
+async def fetch_news_for_keywords(
+    pool: asyncpg.Pool,
+    keywords: list[str],
+    limit: int = 10,
+) -> list[asyncpg.Record]:
+    """Fetch news_article rows matching any of the given keywords in title."""
+    try:
+        # Build parameterized OR conditions — only indices are interpolated, not user input
+        conditions = " OR ".join(f"title ILIKE ${i + 1}" for i in range(len(keywords)))
+        query = f"""
+            SELECT id::text, title, url, source, publish_time, body
+            FROM news_article
+            WHERE {conditions}
+            ORDER BY publish_time DESC
+            LIMIT ${len(keywords) + 1}
+        """  # noqa: S608
+        params: list[object] = [f"%{kw}%" for kw in keywords]
+        params.append(limit)
+        async with pool.acquire() as conn:
+            return await conn.fetch(query, *params)
+    except Exception as exc:
+        logger.error("fetch_news_for_keywords_failed", keywords=keywords, error=str(exc))
+        raise
+
+
+async def fetch_sns_for_keywords(
+    pool: asyncpg.Pool,
+    keywords: list[str],
+    limit: int = 20,
+) -> list[asyncpg.Record]:
+    """Fetch sns_trend rows matching any of the given keywords."""
+    try:
+        # Build parameterized OR conditions — only indices are interpolated, not user input
+        conditions = " OR ".join(f"keyword ILIKE ${i + 1}" for i in range(len(keywords)))
+        query = f"""
+            SELECT id::text, platform, keyword, locale, score, snapshot_at
+            FROM sns_trend
+            WHERE {conditions}
+            ORDER BY score DESC
+            LIMIT ${len(keywords) + 1}
+        """  # noqa: S608
+        params: list[object] = [f"%{kw}%" for kw in keywords]
+        params.append(limit)
+        async with pool.acquire() as conn:
+            return await conn.fetch(query, *params)
+    except Exception as exc:
+        logger.error("fetch_sns_for_keywords_failed", keywords=keywords, error=str(exc))
+        raise
+
+
 async def fetch_news_for_keyword(
     pool: asyncpg.Pool,
     keyword: str,

--- a/frontend/src/routes/trends/[id]/insights/+page.svelte
+++ b/frontend/src/routes/trends/[id]/insights/+page.svelte
@@ -19,13 +19,14 @@
 	let planGateOpen = $state(false);
 	let requiredPlan = $state('pro');
 
-	const keyword = $derived(page.params.id ?? '');
+	const groupId = $derived(page.params.id ?? '');
 	const userRole = $derived(authStore.user?.role ?? 'general');
+	const displayKeyword = $derived(insight?.keyword ?? '');
 
 	async function loadInsight(): Promise<void> {
 		try {
 			const data = await apiRequest<InsightResponse>(
-				`/trends/${encodeURIComponent(keyword)}/insights?role=${userRole}`
+				`/trends/${encodeURIComponent(groupId)}/insights?role=${userRole}`
 			);
 			insight = data;
 		} catch (error) {
@@ -52,9 +53,11 @@
 
 <div class="space-y-6">
 	<div>
-		<a href="/trends" class="text-sm text-blue-600 hover:underline">&larr; {$t('page.trends.title')}</a>
+		<a href="/trends/{groupId}" class="text-sm text-blue-600 hover:underline">&larr; {$t('nav.sidebar.trends')}</a>
 		<h1 class="mt-2 text-2xl font-bold text-gray-900">{$t('page.insights.title')}</h1>
-		<p class="text-gray-600">{keyword}</p>
+		{#if displayKeyword}
+			<p class="text-gray-600">{displayKeyword}</p>
+		{/if}
 	</div>
 
 	{#if isLoading}

--- a/tests/test_db_queries_insights.py
+++ b/tests/test_db_queries_insights.py
@@ -8,8 +8,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from backend.db.queries.insights import (
+    fetch_group_info,
     fetch_news_for_keyword,
+    fetch_news_for_keywords,
     fetch_sns_for_keyword,
+    fetch_sns_for_keywords,
     get_insight_usage,
     increment_insight_usage,
     insert_action_insight,
@@ -88,6 +91,94 @@ def _usage_row() -> dict:
         "quota_limit": 3,
         "reset_at": datetime.now(tz=timezone.utc),
     }
+
+
+class TestFetchGroupInfo:
+    @pytest.mark.asyncio
+    async def test_fetch_group_info_returns_record(self) -> None:
+        row = {"title": "AI 트렌드", "keywords": ["AI", "인공지능"]}
+        pool = _make_pool(fetchrow_return=row)
+
+        result = await fetch_group_info(pool, str(uuid.uuid4()))
+
+        assert result is not None
+        assert result["title"] == "AI 트렌드"
+        assert result["keywords"] == ["AI", "인공지능"]
+
+    @pytest.mark.asyncio
+    async def test_fetch_group_info_returns_none_for_missing(self) -> None:
+        pool = _make_pool(fetchrow_return=None)
+
+        result = await fetch_group_info(pool, str(uuid.uuid4()))
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_fetch_group_info_db_error_raises(self) -> None:
+        pool = MagicMock()
+        conn = AsyncMock()
+        conn.fetchrow = AsyncMock(side_effect=Exception("DB error"))
+        pool.acquire = MagicMock(
+            return_value=MagicMock(
+                __aenter__=AsyncMock(return_value=conn),
+                __aexit__=AsyncMock(return_value=None),
+            )
+        )
+
+        with pytest.raises(Exception, match="DB error"):
+            await fetch_group_info(pool, str(uuid.uuid4()))
+
+
+class TestFetchNewsForKeywords:
+    @pytest.mark.asyncio
+    async def test_fetch_news_for_keywords_returns_rows(self) -> None:
+        rows = _news_rows()
+        pool = _make_pool(fetch_return=rows)
+
+        result = await fetch_news_for_keywords(pool, ["AI", "인공지능"])
+
+        assert result == rows
+
+    @pytest.mark.asyncio
+    async def test_fetch_news_for_keywords_builds_or_query(self) -> None:
+        pool = _make_pool(fetch_return=[])
+        conn = pool.acquire.return_value.__aenter__.return_value
+
+        await fetch_news_for_keywords(pool, ["AI", "트렌드"], limit=5)
+
+        call_args = conn.fetch.call_args
+        sql: str = call_args[0][0]
+        assert "ILIKE $1" in sql
+        assert "ILIKE $2" in sql
+        assert call_args[0][1] == "%AI%"
+        assert call_args[0][2] == "%트렌드%"
+        assert call_args[0][3] == 5
+
+
+class TestFetchSnsForKeywords:
+    @pytest.mark.asyncio
+    async def test_fetch_sns_for_keywords_returns_rows(self) -> None:
+        rows = _sns_rows()
+        pool = _make_pool(fetch_return=rows)
+
+        result = await fetch_sns_for_keywords(pool, ["AI", "트렌드"])
+
+        assert result == rows
+
+    @pytest.mark.asyncio
+    async def test_fetch_sns_for_keywords_builds_or_query(self) -> None:
+        pool = _make_pool(fetch_return=[])
+        conn = pool.acquire.return_value.__aenter__.return_value
+
+        await fetch_sns_for_keywords(pool, ["AI", "머신러닝"], limit=10)
+
+        call_args = conn.fetch.call_args
+        sql: str = call_args[0][0]
+        assert "ILIKE $1" in sql
+        assert "ILIKE $2" in sql
+        assert call_args[0][1] == "%AI%"
+        assert call_args[0][2] == "%머신러닝%"
+        assert call_args[0][3] == 10
 
 
 class TestFetchNewsForKeyword:

--- a/tests/test_insights_api.py
+++ b/tests/test_insights_api.py
@@ -1,4 +1,4 @@
-"""Tests for GET /api/v1/trends/{keyword}/insights endpoint."""
+"""Tests for GET /api/v1/trends/{group_id}/insights endpoint."""
 
 from __future__ import annotations
 
@@ -356,3 +356,114 @@ class TestParseContent:
         content = resp.json()["content"]
         assert "sns_drafts" in content
         assert "engagement_methods" in content
+
+
+class TestGetTrendInsightsGroupId:
+    """Tests for UUID-based group_id path (the primary use case from frontend)."""
+
+    async def test_uuid_group_id_resolves_keywords(
+        self, mock_db_pool: MagicMock, mock_redis: AsyncMock
+    ) -> None:
+        from backend.api.main import create_app
+
+        app = create_app()
+        app.state.db_pool = mock_db_pool
+
+        pro_user = _make_pro_user()
+        app.dependency_overrides[require_auth] = lambda: pro_user
+        app.dependency_overrides[rate_limit_check] = lambda: pro_user
+        app.dependency_overrides[check_insight_quota] = lambda: pro_user
+
+        pro_token = create_access_token("user-pro-001", "pro", "general")
+
+        group_uuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        mock_group_info = MagicMock()
+        mock_group_info.__getitem__ = lambda self, key: {
+            "title": "AI 트렌드",
+            "keywords": ["AI", "인공지능", "머신러닝"],
+        }[key]
+
+        engine_result = _make_engine_result("general")
+
+        with (
+            patch("backend.api.routers.health.get_redis", return_value=mock_redis),
+            patch("backend.api.middleware.rate_limit.get_redis", return_value=mock_redis),
+            patch(
+                "backend.api.routers.insights.get_ai_config",
+                new=AsyncMock(return_value=_make_ai_config()),
+            ),
+            patch(
+                "backend.api.routers.insights.fetch_group_info",
+                new=AsyncMock(return_value=mock_group_info),
+            ),
+            patch(
+                "backend.api.routers.insights.fetch_news_for_keywords",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
+                "backend.api.routers.insights.fetch_sns_for_keywords",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
+                "backend.api.routers.insights.write_audit_log",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "backend.api.routers.insights.increment_insight_usage",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "backend.api.routers.insights.ActionInsightEngine.generate",
+                new=AsyncMock(return_value=engine_result),
+            ),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+                headers={"Authorization": f"Bearer {pro_token}"},
+            ) as ac:
+                resp = await ac.get(f"/api/v1/trends/{group_uuid}/insights")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["keyword"] == "AI 트렌드"
+        app.dependency_overrides.clear()
+
+    async def test_uuid_group_not_found_returns_404(
+        self, mock_db_pool: MagicMock, mock_redis: AsyncMock
+    ) -> None:
+        from backend.api.main import create_app
+
+        app = create_app()
+        app.state.db_pool = mock_db_pool
+
+        pro_user = _make_pro_user()
+        app.dependency_overrides[require_auth] = lambda: pro_user
+        app.dependency_overrides[rate_limit_check] = lambda: pro_user
+        app.dependency_overrides[check_insight_quota] = lambda: pro_user
+
+        pro_token = create_access_token("user-pro-001", "pro", "general")
+
+        group_uuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+        with (
+            patch("backend.api.routers.health.get_redis", return_value=mock_redis),
+            patch("backend.api.middleware.rate_limit.get_redis", return_value=mock_redis),
+            patch(
+                "backend.api.routers.insights.get_ai_config",
+                new=AsyncMock(return_value=_make_ai_config()),
+            ),
+            patch(
+                "backend.api.routers.insights.fetch_group_info",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+                headers={"Authorization": f"Bearer {pro_token}"},
+            ) as ac:
+                resp = await ac.get(f"/api/v1/trends/{group_uuid}/insights")
+
+        assert resp.status_code == 404
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- 인사이트 페이지가 UUID를 keyword로 전송하여 항상 빈 결과를 반환하던 버그 수정
- 백엔드에서 UUID 감지 시 news_group 조회 후 title/keywords 기반 다중 키워드 검색
- 프론트엔드에서 UUID 대신 실제 키워드를 표시하고 뒤로가기 링크를 트렌드 상세 페이지로 변경

## Changes
- `backend/api/routers/insights.py`: 라우트 파라미터 `{keyword}` → `{group_id}`, UUID 감지 + 그룹 정보 조회 로직
- `backend/db/queries/insights.py`: `fetch_group_info()`, `fetch_news_for_keywords()`, `fetch_sns_for_keywords()` 추가
- `frontend/src/routes/trends/[id]/insights/+page.svelte`: UUID 대신 응답 keyword 표시
- 비-UUID 레거시 경로 하위 호환성 유지

## Test plan
- [x] 790 passed, 74.24% coverage
- [x] UUID 기반 인사이트 조회 테스트 추가 (`TestGetTrendInsightsGroupId`)
- [x] 그룹 미존재 시 404 반환 테스트
- [x] 기존 keyword 기반 테스트 모두 통과 (하위 호환)
- [x] DB 쿼리 단위 테스트 추가 (`TestFetchGroupInfo`, `TestFetchNewsForKeywords`, `TestFetchSnsForKeywords`)

Closes: #68