### PR TITLE
Fix: early_trend_score 파이프라인 통합

### DIFF
--- a/backend/processor/pipeline.py
+++ b/backend/processor/pipeline.py
@@ -266,9 +266,14 @@ async def _stage_match_existing_groups(
                     new_score_result: ScoreResult = calculate_score(score_input)
                     new_score = max(best_current_score, new_score_result.total)
 
+                    # Recalculate early_trend_score based on updated article count
+                    early_score = min(1.0, new_article_count / 10.0) * 0.4 + 0.3
+
                     await db_pool.execute(
-                        "UPDATE news_group SET score = $1, updated_at = now() WHERE id = $2",
+                        "UPDATE news_group SET score = $1, early_trend_score = $2, "
+                        "updated_at = now() WHERE id = $3",
                         new_score,
+                        early_score,
                         best_group_id,
                     )
                 except Exception as score_exc:
@@ -341,6 +346,41 @@ def _stage_cluster(articles: list[dict[str, Any]]) -> list[Cluster]:
         return []
 
 
+def _compute_early_trend_score(articles: list[dict[str, Any]]) -> float:
+    """Compute a lightweight early trend score from cluster article data.
+
+    Combines three signals:
+    - velocity: normalized article count (more articles = faster growing)
+    - source_diversity: ratio of unique sources (broader coverage = stronger signal)
+    - recency: how recent the newest article is (newer = more likely emerging)
+
+    Returns a score in [0.0, 1.0].
+    """
+    if not articles:
+        return 0.0
+
+    # Velocity: article count normalized (10+ articles → 1.0)
+    velocity = min(1.0, len(articles) / 10.0)
+
+    # Source diversity: unique sources / total articles
+    sources = {a.get("source", "") for a in articles if a.get("source")}
+    source_diversity = len(sources) / max(len(articles), 1)
+
+    # Recency: newest article within last 6 hours → 1.0, 48h+ → 0.0
+    now = datetime.now(tz=timezone.utc)
+    newest_hours = 48.0
+    for a in articles:
+        pub_time = a.get("publish_time")
+        if isinstance(pub_time, str):
+            pub_time = datetime.fromisoformat(pub_time)
+        if isinstance(pub_time, datetime):
+            hours_ago = (now - pub_time).total_seconds() / 3600
+            newest_hours = min(newest_hours, max(0.0, hours_ago))
+    recency = max(0.0, 1.0 - (newest_hours / 48.0))
+
+    return round(0.4 * velocity + 0.3 * source_diversity + 0.3 * recency, 4)
+
+
 def _stage_score(clusters: list[Cluster]) -> list[dict[str, Any]]:
     """Stage 6: Calculate score for each cluster."""
     scored: list[dict[str, Any]] = []
@@ -367,11 +407,14 @@ def _stage_score(clusters: list[Cluster]) -> list[dict[str, Any]]:
                 all_keywords.extend(a.get("keywords", []))
             unique_keywords = list(dict.fromkeys(all_keywords))[:20]
 
+            early_score = _compute_early_trend_score(articles)
+
             scored.append(
                 {
                     "cluster": cluster,
                     "articles": articles,
                     "score": result.total,
+                    "early_trend_score": early_score,
                     "title": rep_article.get("title", ""),
                     "category": rep_article.get("category", "general"),
                     "locale": rep_article.get("locale", "ko"),
@@ -430,13 +473,15 @@ async def _stage_save(
     for item in scored_clusters:
         try:
             group_id = await db_pool.fetchval(
-                "INSERT INTO news_group (category, locale, title, summary, score, keywords) "
-                "VALUES ($1, $2, $3, $4, $5, $6) RETURNING id",
+                "INSERT INTO news_group "
+                "(category, locale, title, summary, score, early_trend_score, keywords) "
+                "VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id",
                 item["category"],
                 item["locale"],
                 item["title"],
                 item.get("summary"),
                 item["score"],
+                item.get("early_trend_score", 0.0),
                 item["keywords"],
             )
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from backend.processor.pipeline import (
+    _compute_early_trend_score,
     _stage_dedupe,
     _stage_extract_keywords,
     _stage_normalize,
@@ -101,6 +102,38 @@ class TestStageExtractKeywords:
         assert result[0]["keyword_importance"] == 0.0
 
 
+class TestComputeEarlyTrendScore:
+    def test_empty_articles_returns_zero(self) -> None:
+        assert _compute_early_trend_score([]) == 0.0
+
+    def test_single_recent_article(self) -> None:
+        articles = [_make_article()]
+        score = _compute_early_trend_score(articles)
+        assert 0.0 < score <= 1.0
+
+    def test_more_articles_higher_velocity(self) -> None:
+        one = [_make_article()]
+        many = [_make_article(url=f"https://example.com/{i}", url_hash=f"h{i}") for i in range(10)]
+        assert _compute_early_trend_score(many) > _compute_early_trend_score(one)
+
+    def test_diverse_sources_higher_score(self) -> None:
+        same_source = [
+            _make_article(url=f"https://example.com/{i}", url_hash=f"h{i}") for i in range(3)
+        ]
+        diverse = [
+            {**_make_article(url=f"https://example.com/{i}", url_hash=f"h{i}"), "source": f"src{i}"}
+            for i in range(3)
+        ]
+        assert _compute_early_trend_score(diverse) > _compute_early_trend_score(same_source)
+
+    def test_score_bounded_zero_to_one(self) -> None:
+        articles = [
+            _make_article(url=f"https://example.com/{i}", url_hash=f"h{i}") for i in range(20)
+        ]
+        score = _compute_early_trend_score(articles)
+        assert 0.0 <= score <= 1.0
+
+
 class TestStageScore:
     def test_returns_scored_clusters(self) -> None:
         article = _make_article()
@@ -121,6 +154,8 @@ class TestStageScore:
         assert len(result) == 1
         assert "score" in result[0]
         assert result[0]["score"] >= 0
+        assert "early_trend_score" in result[0]
+        assert 0.0 <= result[0]["early_trend_score"] <= 1.0
 
 
 class TestStageWarmCache:


### PR DESCRIPTION
## Summary
- early_trend_score가 한 번도 계산되지 않던 문제 수정
- `_compute_early_trend_score()` 추가: velocity(기사 수) + source_diversity(출처 다양성) + recency(최신성) 기반 [0,1] 점수
- 파이프라인 scoring 단계에서 계산, save 단계에서 DB 저장
- 기존 그룹 매칭 시에도 early_trend_score 업데이트

## Test plan
- [x] 786 passed, 74.20% coverage
- [x] `TestComputeEarlyTrendScore`: 빈 입력, 단일 기사, 기사 수 증가 시 점수 상승, 출처 다양성 테스트, 범위 검증
- [x] `TestStageScore`: early_trend_score 필드 포함 확인

Closes: #70