### PR TITLE
Fix: 캐시 압축 데이터 미해제 — zlib prefix 방식으로 수정

### DIFF
--- a/backend/processor/shared/cache_manager.py
+++ b/backend/processor/shared/cache_manager.py
@@ -17,6 +17,12 @@ _redis_pool: aioredis.Redis | None = None
 LOCK_TTL_SECONDS = 30
 DEFAULT_COMPRESS_THRESHOLD = 1024  # bytes
 
+# 1-byte prefix constants for compression marker
+_PREFIX_COMPRESSED: bytes = b"\x01"
+_PREFIX_UNCOMPRESSED: bytes = b"\x00"
+# zlib magic bytes for backwards-compatibility detection (no prefix)
+_ZLIB_MAGIC: tuple[bytes, ...] = (b"\x78\x01", b"\x78\x9c", b"\x78\xda")
+
 
 async def init_redis(redis_url: str) -> None:
     """Initialize the global Redis connection pool."""
@@ -45,12 +51,49 @@ def get_redis() -> aioredis.Redis:
     return _redis_pool
 
 
+def _decompress_value(raw: bytes) -> bytes:
+    """Decode a stored cache value, handling prefix and legacy formats.
+
+    Format (new):
+      b'\\x01' + zlib.compress(data)  — compressed
+      b'\\x00' + data                 — uncompressed
+
+    Format (legacy, no prefix):
+      Detect zlib magic bytes and decompress; otherwise return as-is.
+    """
+    if len(raw) < 1:
+        return raw
+
+    first = raw[:1]
+
+    if first == _PREFIX_COMPRESSED:
+        return zlib.decompress(raw[1:])
+
+    if first == _PREFIX_UNCOMPRESSED:
+        return raw[1:]
+
+    # Backwards-compatibility: data written before the prefix scheme
+    if raw[:2] in _ZLIB_MAGIC:
+        try:
+            return zlib.decompress(raw)
+        except zlib.error:
+            logger.warning("cache_decompress_legacy_failed_returning_raw")
+            return raw
+
+    return raw
+
+
 async def get_cached(key: str) -> bytes | None:
-    """Return cached bytes for key, or None on miss / error."""
+    """Return cached bytes for key, or None on miss / error.
+
+    Transparently decompresses values stored with set_cached().
+    """
     try:
-        value = await get_redis().get(key)
-        CACHE_REQUESTS.labels(result="hit" if value is not None else "miss").inc()
-        return value
+        raw = await get_redis().get(key)
+        CACHE_REQUESTS.labels(result="hit" if raw is not None else "miss").inc()
+        if raw is None:
+            return None
+        return _decompress_value(raw)
     except Exception as exc:
         CACHE_REQUESTS.labels(result="miss").inc()
         logger.warning("cache_get_failed", key=key, error=str(exc))
@@ -58,12 +101,18 @@ async def get_cached(key: str) -> bytes | None:
 
 
 async def set_cached(key: str, value: bytes | str, ttl: int) -> None:
-    """Set key with TTL. Compresses values larger than threshold."""
+    """Set key with TTL.
+
+    Compresses values larger than threshold and prepends a 1-byte prefix
+    so get_cached() can reliably decompress on retrieval.
+    """
     try:
         data = value if isinstance(value, bytes) else value.encode()
         if len(data) > DEFAULT_COMPRESS_THRESHOLD:
-            data = zlib.compress(data)
-        await get_redis().setex(key, ttl, data)
+            stored = _PREFIX_COMPRESSED + zlib.compress(data)
+        else:
+            stored = _PREFIX_UNCOMPRESSED + data
+        await get_redis().setex(key, ttl, stored)
     except Exception as exc:
         logger.warning("cache_set_failed", key=key, error=str(exc))
 
@@ -108,6 +157,9 @@ async def get_or_compute(
 
     On cache miss: acquires lock, computes, stores, releases lock.
     On lock failure with stale_on_lock=True: returns stale value if present.
+
+    get_cached() transparently decompresses, so callers always receive
+    plain bytes regardless of whether the value was compressed at write time.
     """
     cached = await get_cached(key)
     if cached is not None:

--- a/tests/test_cache_manager.py
+++ b/tests/test_cache_manager.py
@@ -43,8 +43,10 @@ async def test_close_redis() -> None:
 
 @pytest.mark.asyncio
 async def test_get_cached_hit() -> None:
+    """Uncompressed value stored with new prefix is returned without prefix."""
     mock_redis = AsyncMock()
-    mock_redis.get = AsyncMock(return_value=b"cached_value")
+    # Simulate a value written by the new set_cached (uncompressed prefix b'\x00')
+    mock_redis.get = AsyncMock(return_value=b"\x00cached_value")
     cache_manager._redis_pool = mock_redis
 
     result = await cache_manager.get_cached("test_key")
@@ -163,7 +165,8 @@ async def test_release_lock() -> None:
 @pytest.mark.asyncio
 async def test_get_or_compute_cache_hit() -> None:
     mock_redis = AsyncMock()
-    mock_redis.get = AsyncMock(return_value=b"cached")
+    # Prefixed uncompressed value
+    mock_redis.get = AsyncMock(return_value=b"\x00cached")
     cache_manager._redis_pool = mock_redis
 
     compute_fn = AsyncMock(return_value=b"computed")
@@ -193,3 +196,112 @@ async def test_get_or_compute_cache_miss_with_lock() -> None:
     compute_fn = AsyncMock(return_value=b"fresh_value")
     result = await cache_manager.get_or_compute("key", compute_fn, 60)
     assert result == b"fresh_value"
+
+
+# --- Compression / decompression round-trip tests ---
+
+
+def test_decompress_value_uncompressed_prefix() -> None:
+    """Values stored with \\x00 prefix are returned without the prefix."""
+    raw = b"\x00hello world"
+    assert cache_manager._decompress_value(raw) == b"hello world"
+
+
+def test_decompress_value_compressed_prefix() -> None:
+    """Values stored with \\x01 prefix are decompressed correctly."""
+    original = b"hello world" * 200
+    compressed = cache_manager._PREFIX_COMPRESSED + __import__("zlib").compress(original)
+    assert cache_manager._decompress_value(compressed) == original
+
+
+def test_decompress_value_legacy_zlib() -> None:
+    """Legacy values (no prefix, raw zlib) are detected and decompressed."""
+    import zlib
+
+    original = b"legacy data" * 200
+    raw = zlib.compress(original)  # starts with \x78\x9c or similar
+    assert cache_manager._decompress_value(raw) == original
+
+
+def test_decompress_value_legacy_plain() -> None:
+    """Legacy values that are neither prefixed nor zlib are returned as-is."""
+    raw = b"plain old bytes"
+    assert cache_manager._decompress_value(raw) == raw
+
+
+def test_decompress_value_empty() -> None:
+    assert cache_manager._decompress_value(b"") == b""
+
+
+@pytest.mark.asyncio
+async def test_set_cached_small_value_stores_uncompressed_prefix() -> None:
+    """Small values are stored with \\x00 prefix (no compression)."""
+    mock_redis = AsyncMock()
+    mock_redis.setex = AsyncMock()
+    cache_manager._redis_pool = mock_redis
+
+    payload = b"small"
+    await cache_manager.set_cached("k", payload, 60)
+
+    args = mock_redis.setex.call_args[0]
+    stored: bytes = args[2]
+    assert stored[:1] == b"\x00"
+    assert stored[1:] == payload
+
+
+@pytest.mark.asyncio
+async def test_set_cached_large_value_stores_compressed_prefix() -> None:
+    """Values over threshold are stored with \\x01 prefix and zlib-compressed."""
+    import zlib
+
+    mock_redis = AsyncMock()
+    mock_redis.setex = AsyncMock()
+    cache_manager._redis_pool = mock_redis
+
+    payload = b"x" * 2000  # exceeds DEFAULT_COMPRESS_THRESHOLD
+    await cache_manager.set_cached("k", payload, 60)
+
+    args = mock_redis.setex.call_args[0]
+    stored: bytes = args[2]
+    assert stored[:1] == b"\x01"
+    assert zlib.decompress(stored[1:]) == payload
+
+
+@pytest.mark.asyncio
+async def test_get_cached_decompresses_compressed_value() -> None:
+    """get_cached() transparently decompresses a \\x01-prefixed value."""
+    import zlib
+
+    original = b"important json data" * 100
+    compressed_stored = b"\x01" + zlib.compress(original)
+
+    mock_redis = AsyncMock()
+    mock_redis.get = AsyncMock(return_value=compressed_stored)
+    cache_manager._redis_pool = mock_redis
+
+    result = await cache_manager.get_cached("k")
+    assert result == original
+
+
+@pytest.mark.asyncio
+async def test_set_get_round_trip_large_value() -> None:
+    """set_cached then get_cached returns the original bytes for large values."""
+    stored_value: bytes | None = None
+
+    mock_redis = AsyncMock()
+
+    async def fake_setex(key: str, ttl: int, value: bytes) -> None:
+        nonlocal stored_value
+        stored_value = value
+
+    async def fake_get(key: str) -> bytes | None:
+        return stored_value
+
+    mock_redis.setex = fake_setex
+    mock_redis.get = fake_get
+    cache_manager._redis_pool = mock_redis
+
+    original = b"round trip test data" * 200  # > 1024 bytes
+    await cache_manager.set_cached("k", original, 60)
+    result = await cache_manager.get_cached("k")
+    assert result == original


### PR DESCRIPTION
## Summary

- `set_cached()`에서 zlib 압축 후 `get_cached()`에서 미해제하여 트렌드 페이지에 바이너리 응답 반환되는 버그 수정
- 1-byte prefix 방식 도입: `\x01` = 압축, `\x00` = 비압축
- 기존 캐시 데이터(prefix 없음) 하위 호환: zlib magic bytes 감지 후 자동 해제

## Changes

- `backend/processor/shared/cache_manager.py`: `_decompress_value()` 헬퍼 추가, `set_cached()` prefix 저장, `get_cached()` 자동 해제
- `tests/test_cache_manager.py`: 압축/해제 round-trip 및 legacy 포맷 커버 테스트 10건 추가

## Test plan

- [x] `test_decompress_value_uncompressed_prefix` — `\x00` prefix 제거 확인
- [x] `test_decompress_value_compressed_prefix` — `\x01` prefix + decompress 확인
- [x] `test_decompress_value_legacy_zlib` — magic bytes 감지 후 decompress 확인
- [x] `test_decompress_value_legacy_plain` — 비압축 raw bytes 그대로 반환 확인
- [x] `test_set_get_round_trip_large_value` — 대용량 값 set→get round-trip 확인
- [x] 790 tests passed, 74.21% coverage, ruff OK

Closes: #79