### PR TITLE
커뮤니티 크롤러 body 추출 기능 추가

### DIFF
--- a/backend/crawler/sources/community_crawler.py
+++ b/backend/crawler/sources/community_crawler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import re
 import time
@@ -16,6 +17,7 @@ from bs4 import BeautifulSoup
 
 from backend.common.metrics import CRAWLER_REQUESTS
 from backend.crawler.quota_guard import check_quota, increment_quota
+from backend.crawler.sources.extractor import extract_body
 from backend.crawler.sources.robots import is_allowed
 from backend.crawler.sources.rss_feeds import FeedSource
 from backend.db.queries.feed_sources import get_feed_sources_for_crawl, update_feed_health
@@ -26,6 +28,8 @@ _TRAILING_NUM_RE = re.compile(r"\s+\d+\s*$")
 logger = structlog.get_logger(__name__)
 
 _HTTP_TIMEOUT = 15.0
+_MIN_BODY_LENGTH = 30
+_BODY_FETCH_DELAY = 0.5
 
 
 def _url_hash(url: str) -> str:
@@ -170,6 +174,10 @@ async def _crawl_rss_feed(
                 continue
 
             body = entry.get("summary", "").strip()
+
+            if len(body) < _MIN_BODY_LENGTH and await is_allowed(url):
+                body = await _fetch_article_body(client, url)
+
             cfp = _content_fp(title, body)
             published = _parse_time(entry)
 
@@ -252,7 +260,11 @@ async def _crawl_fm_html(
                 if existing:
                     continue
 
-                cfp = _content_fp(title, "")
+                body = ""
+                if await is_allowed(href):
+                    body = await _fetch_article_body(client, href)
+
+                cfp = _content_fp(title, body)
 
                 await db_pool.execute(
                     "INSERT INTO news_article "
@@ -264,7 +276,7 @@ async def _crawl_fm_html(
                     uhash,
                     cfp,
                     title,
-                    "",
+                    body,
                     feed["name"],
                     "",
                     datetime.now(tz=timezone.utc),
@@ -278,7 +290,7 @@ async def _crawl_fm_html(
                         "url_hash": uhash,
                         "content_fp": cfp,
                         "title": title,
-                        "body": "",
+                        "body": body,
                         "source": feed["name"],
                         "publish_time": datetime.now(tz=timezone.utc),
                         "locale": feed["locale"],
@@ -293,6 +305,22 @@ async def _crawl_fm_html(
     except Exception as exc:
         logger.warning("fm_html_crawl_failed", error=str(exc))
         return []
+
+
+async def _fetch_article_body(client: httpx.AsyncClient, url: str) -> str:
+    """Fetch original article HTML and extract body text via extractor."""
+    try:
+        await asyncio.sleep(_BODY_FETCH_DELAY)
+        resp = await client.get(url)
+        if resp.status_code != 200:
+            logger.debug("body_fetch_http_error", url=url, status=resp.status_code)
+            return ""
+        body = await extract_body(url, html=resp.text)
+        logger.debug("body_extracted", url=url, length=len(body))
+        return body
+    except Exception as exc:
+        logger.warning("body_fetch_failed", url=url, error=str(exc))
+        return ""
 
 
 def _parse_time(entry: Any) -> datetime:  # noqa: ANN401

--- a/tests/test_community_crawler.py
+++ b/tests/test_community_crawler.py
@@ -6,8 +6,10 @@ import time
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from backend.crawler.sources.community_crawler import (
     _content_fp,
+    _fetch_article_body,
     _parse_time,
     _url_hash,
     crawl_all,
@@ -66,6 +68,80 @@ class TestParseTime:
         entry.updated_parsed = time.localtime()
         result = _parse_time(entry)
         assert isinstance(result, datetime)
+
+
+class TestFetchArticleBody:
+    @pytest.mark.asyncio
+    async def test_extracts_body_from_html(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = "<html><body><p>본문 텍스트입니다. 충분히 긴 본문.</p></body></html>"
+
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        with (
+            patch(
+                "backend.crawler.sources.community_crawler.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "backend.crawler.sources.community_crawler.extract_body",
+                AsyncMock(return_value="본문 텍스트입니다. 충분히 긴 본문."),
+            ) as mock_extract,
+        ):
+            result = await _fetch_article_body(mock_client, "https://example.com/article")
+            assert result == "본문 텍스트입니다. 충분히 긴 본문."
+            mock_extract.assert_called_once_with("https://example.com/article", html=mock_resp.text)
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_http_error(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 403
+
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        with patch(
+            "backend.crawler.sources.community_crawler.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            result = await _fetch_article_body(mock_client, "https://example.com/blocked")
+            assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_exception(self) -> None:
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock(side_effect=RuntimeError("timeout"))
+
+        with patch(
+            "backend.crawler.sources.community_crawler.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            result = await _fetch_article_body(mock_client, "https://example.com/timeout")
+            assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_respects_delay(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = "<html><body>text</body></html>"
+
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        with (
+            patch(
+                "backend.crawler.sources.community_crawler.asyncio.sleep",
+                new_callable=AsyncMock,
+            ) as mock_sleep,
+            patch(
+                "backend.crawler.sources.community_crawler.extract_body",
+                AsyncMock(return_value=""),
+            ),
+        ):
+            await _fetch_article_body(mock_client, "https://example.com")
+            mock_sleep.assert_called_once_with(0.5)
 
 
 class TestCrawlDcInside:


### PR DESCRIPTION
## Summary
- RSS body가 비어있거나 30자 미만인 커뮤니티 게시글에 대해 원문 URL 크롤링하여 본문 텍스트 추출
- 기존 3-stage extractor (newspaper3k → readability → BS4) 재활용
- FM Korea HTML 스크레이핑 fallback에도 동일 body 추출 적용
- robots.txt 확인 + 0.5초 폴라이트 딜레이로 서버 부담 최소화

## Test plan
- [x] `_fetch_article_body` 성공 케이스 — extractor 호출 확인
- [x] HTTP 에러 시 빈 문자열 반환
- [x] 예외 발생 시 빈 문자열 반환
- [x] 0.5초 딜레이 적용 확인
- [x] ruff lint 통과
- [x] 전체 테스트 827 passed, coverage 74.36%

Closes: #96