### PR TITLE
15분 주기 early_trend_score 재계산 job 추가

### DIFF
--- a/backend/crawler/scheduler.py
+++ b/backend/crawler/scheduler.py
@@ -10,6 +10,7 @@ from backend.crawler.quota_guard import reset_all_quotas
 from backend.crawler.sources.community_crawler import crawl_all as community_crawl_all
 from backend.crawler.sources.news_crawler import crawl_all as news_crawl_all
 from backend.crawler.sources.sns_crawler import collect_all as sns_collect_all
+from backend.jobs.early_trend_update import run_early_trend_update
 
 logger = structlog.get_logger(__name__)
 
@@ -39,6 +40,15 @@ async def _job_community_crawl(db_pool: asyncpg.Pool) -> None:
         logger.info("scheduled_community_crawl_done", articles=len(articles))
     except Exception as exc:
         logger.error("scheduled_community_crawl_failed", error=str(exc))
+
+
+async def _job_early_trend_update(db_pool: asyncpg.Pool) -> None:
+    """Scheduled job: recalculate early_trend_score every 15 minutes."""
+    try:
+        updated = await run_early_trend_update(db_pool)
+        logger.info("scheduled_early_trend_update_done", updated=updated)
+    except Exception as exc:
+        logger.error("scheduled_early_trend_update_failed", error=str(exc))
 
 
 async def _job_quota_reset(db_pool: asyncpg.Pool) -> None:
@@ -90,6 +100,17 @@ def create_scheduler(db_pool: asyncpg.Pool) -> AsyncIOScheduler:
         args=[db_pool],
         id="community_crawl",
         name="Community Crawler",
+        max_instances=1,
+        coalesce=True,
+    )
+
+    scheduler.add_job(
+        _job_early_trend_update,
+        "interval",
+        minutes=15,
+        args=[db_pool],
+        id="early_trend_update",
+        name="Early Trend Score Recalculation",
         max_instances=1,
         coalesce=True,
     )

--- a/backend/jobs/early_trend_update.py
+++ b/backend/jobs/early_trend_update.py
@@ -1,0 +1,92 @@
+"""Scheduled job: recalculate early_trend_score for active news groups (15-min cycle)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import asyncpg
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+_ACTIVE_WINDOW_HOURS = 48
+_MAX_ARTICLES_PER_GROUP = 10.0
+
+
+async def run_early_trend_update(pool: asyncpg.Pool) -> int:
+    """Recalculate early_trend_score for news groups active in the last 48 hours.
+
+    Formula (same as pipeline._compute_early_trend_score):
+        velocity = min(1.0, article_count / 10)
+        source_diversity = unique_sources / article_count
+        recency = max(0.0, 1.0 - newest_hours_ago / 48.0)
+        score = 0.4 * velocity + 0.3 * source_diversity + 0.3 * recency
+
+    Returns the number of groups updated.
+    """
+    try:
+        async with pool.acquire() as conn:
+            groups = await conn.fetch(
+                """
+                SELECT ng.id,
+                       COUNT(na.id)::int AS article_count,
+                       COUNT(DISTINCT na.source)::int AS unique_sources,
+                       MAX(na.publish_time) AS newest_publish_time
+                FROM news_group ng
+                JOIN news_article na ON na.group_id = ng.id
+                WHERE ng.created_at > now() - INTERVAL '48 hours'
+                GROUP BY ng.id
+                """,
+            )
+
+        if not groups:
+            logger.info("early_trend_update_skip", reason="no_active_groups")
+            return 0
+
+        now = datetime.now(tz=timezone.utc)
+        updated = 0
+
+        async with pool.acquire() as conn:
+            for row in groups:
+                try:
+                    article_count = row["article_count"]
+                    unique_sources = row["unique_sources"]
+                    newest_time = row["newest_publish_time"]
+
+                    velocity = min(1.0, article_count / _MAX_ARTICLES_PER_GROUP)
+
+                    source_diversity = unique_sources / max(article_count, 1)
+
+                    if newest_time and newest_time.tzinfo:
+                        hours_ago = (now - newest_time).total_seconds() / 3600
+                    else:
+                        hours_ago = float(_ACTIVE_WINDOW_HOURS)
+                    recency = max(0.0, 1.0 - (hours_ago / _ACTIVE_WINDOW_HOURS))
+
+                    score = round(
+                        0.4 * velocity + 0.3 * source_diversity + 0.3 * recency,
+                        4,
+                    )
+
+                    await conn.execute(
+                        "UPDATE news_group SET early_trend_score = $1 WHERE id = $2",
+                        score,
+                        row["id"],
+                    )
+                    updated += 1
+                except Exception as exc:
+                    logger.warning(
+                        "early_trend_update_row_error",
+                        error=str(exc),
+                    )
+                    continue
+
+        logger.info(
+            "early_trend_update_complete",
+            total_groups=len(groups),
+            updated=updated,
+        )
+        return updated
+    except Exception as exc:
+        logger.error("early_trend_update_failed", error=str(exc))
+        raise

--- a/tests/test_early_trend_update.py
+++ b/tests/test_early_trend_update.py
@@ -1,0 +1,118 @@
+"""Tests for backend.jobs.early_trend_update."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from backend.jobs.early_trend_update import run_early_trend_update
+
+
+def _make_pool(
+    groups: list[dict] | None = None,
+    execute_result: str = "UPDATE 1",
+) -> MagicMock:
+    """Create a mock asyncpg pool with configurable fetch results."""
+    pool = MagicMock()
+
+    mock_conn = MagicMock()
+    mock_conn.fetch = AsyncMock(return_value=groups or [])
+    mock_conn.execute = AsyncMock(return_value=execute_result)
+
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=mock_conn)
+    ctx.__aexit__ = AsyncMock(return_value=None)
+    pool.acquire.return_value = ctx
+
+    return pool
+
+
+def _make_group_row(
+    article_count: int = 5,
+    unique_sources: int = 3,
+    hours_ago: float = 2.0,
+) -> MagicMock:
+    """Create a mock group row."""
+    now = datetime.now(tz=timezone.utc)
+    row = MagicMock()
+    data = {
+        "id": uuid.uuid4(),
+        "article_count": article_count,
+        "unique_sources": unique_sources,
+        "newest_publish_time": now - timedelta(hours=hours_ago),
+    }
+    row.__getitem__ = lambda self, key: data[key]
+    return row
+
+
+class TestRunEarlyTrendUpdate:
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_no_groups(self) -> None:
+        pool = _make_pool(groups=[])
+        result = await run_early_trend_update(pool)
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_updates_groups_and_returns_count(self) -> None:
+        rows = [_make_group_row(article_count=5, unique_sources=3, hours_ago=2.0)]
+        pool = _make_pool(groups=rows)
+        result = await run_early_trend_update(pool)
+        assert result == 1
+
+    @pytest.mark.asyncio
+    async def test_score_calculation_velocity(self) -> None:
+        """10+ articles should give velocity = 1.0."""
+        rows = [_make_group_row(article_count=15, unique_sources=5, hours_ago=0.0)]
+        pool = _make_pool(groups=rows)
+
+        await run_early_trend_update(pool)
+
+        # Verify the UPDATE was called
+        ctx = pool.acquire.return_value
+        conn = await ctx.__aenter__()
+        assert conn.execute.called
+        call_args = conn.execute.call_args_list[-1]
+        score = call_args[0][1]
+        # velocity=1.0, diversity=5/15≈0.33, recency=1.0
+        # 0.4*1.0 + 0.3*0.33 + 0.3*1.0 ≈ 0.7
+        assert 0.6 < score < 0.85
+
+    @pytest.mark.asyncio
+    async def test_score_decreases_with_old_articles(self) -> None:
+        """Articles from 40 hours ago should have low recency."""
+        rows = [_make_group_row(article_count=5, unique_sources=3, hours_ago=40.0)]
+        pool = _make_pool(groups=rows)
+
+        await run_early_trend_update(pool)
+
+        ctx = pool.acquire.return_value
+        conn = await ctx.__aenter__()
+        call_args = conn.execute.call_args_list[-1]
+        score = call_args[0][1]
+        # velocity=0.5, diversity=0.6, recency≈0.17
+        # 0.4*0.5 + 0.3*0.6 + 0.3*0.17 ≈ 0.43
+        assert score < 0.5
+
+    @pytest.mark.asyncio
+    async def test_handles_row_error_gracefully(self) -> None:
+        """A bad row should not stop processing of other rows."""
+        good_row = _make_group_row()
+        bad_row = MagicMock()
+        bad_row.__getitem__ = MagicMock(side_effect=KeyError("article_count"))
+
+        pool = _make_pool(groups=[bad_row, good_row])
+        result = await run_early_trend_update(pool)
+        assert result == 1
+
+    @pytest.mark.asyncio
+    async def test_raises_on_db_connection_error(self) -> None:
+        pool = MagicMock()
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(side_effect=RuntimeError("connection refused"))
+        ctx.__aexit__ = AsyncMock(return_value=None)
+        pool.acquire.return_value = ctx
+
+        with pytest.raises(RuntimeError, match="connection refused"):
+            await run_early_trend_update(pool)


### PR DESCRIPTION
## Summary
- `backend/jobs/early_trend_update.py`: 48시간 내 활성 news_group 대상 early_trend_score 재계산
- velocity(기사수) / source_diversity(소스다양성) / recency(최신성) 3요소 가중평균
- APScheduler에 15분 interval job 등록 (max_instances=1, coalesce=True)
- 파이프라인의 `_compute_early_trend_score`와 동일 공식 사용

## Test plan
- [x] 활성 그룹 없을 때 0 반환
- [x] 정상 업데이트 카운트 반환
- [x] 높은 velocity → 높은 점수 검증
- [x] 오래된 기사 → 낮은 recency 검증
- [x] 개별 row 에러 시 다른 row 처리 계속
- [x] DB 연결 에러 시 예외 전파
- [x] ruff lint 통과, 829 passed, coverage 74.40%

Closes: #98