### PR TITLE
crawler/processor 서비스 로깅 연동

### DIFF
--- a/backend/crawler/main.py
+++ b/backend/crawler/main.py
@@ -9,6 +9,7 @@ import signal
 import asyncpg
 import structlog
 
+from backend.common.logging_config import setup_logging
 from backend.crawler.scheduler import create_scheduler, start_scheduler, stop_scheduler
 from backend.crawler.sources.news_crawler import crawl_all as news_crawl_all
 from backend.processor.shared.cache_manager import close_redis, init_redis
@@ -18,6 +19,8 @@ logger = structlog.get_logger(__name__)
 
 async def main() -> None:
     """Boot crawler: connect DB, run initial crawl, then start scheduler loop."""
+    setup_logging("crawler")
+
     database_url = os.environ.get("DATABASE_URL")
     if not database_url:
         raise RuntimeError("DATABASE_URL not set")

--- a/backend/processor/main.py
+++ b/backend/processor/main.py
@@ -10,6 +10,7 @@ from typing import Any
 import asyncpg
 import structlog
 
+from backend.common.logging_config import setup_logging
 from backend.processor.pipeline import process_articles
 from backend.processor.shared.cache_manager import close_redis, init_redis
 
@@ -56,6 +57,8 @@ async def _poll_loop(db_pool: asyncpg.Pool, stop_event: asyncio.Event) -> None:
 
 async def main() -> None:
     """Boot processor: connect DB, start polling loop."""
+    setup_logging("processor")
+
     database_url = os.environ.get("DATABASE_URL")
     if not database_url:
         raise RuntimeError("DATABASE_URL not set")


### PR DESCRIPTION
## Summary
- crawler/main.py에 `setup_logging("crawler")` 추가
- processor/main.py에 `setup_logging("processor")` 추가
- 기존 logging_config.py의 rotating file handler 활용 (서비스별 로그 분리 + error.log)

## Test plan
- [x] ruff lint 통과
- [x] 전체 테스트 823 passed, coverage 74.30%

Closes: #100