### PR TITLE
Feat: 온보딩 투어 (대시보드 인터랙티브 가이드)

### DIFF
--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -426,5 +426,22 @@
 	"settings.behavior.suggested": "AI-Suggested Weights",
 	"settings.behavior.apply": "Apply Suggested Weights",
 	"settings.behavior.apply_error": "Failed to apply suggested weights.",
-	"settings.behavior.no_data": "Not enough activity data yet. Explore more trends to get personalized suggestions."
+	"settings.behavior.no_data": "Not enough activity data yet. Explore more trends to get personalized suggestions.",
+
+	"tour.skip": "Skip",
+	"tour.next": "Next",
+	"tour.prev": "Back",
+	"tour.finish": "Got it!",
+	"tour.step.stats.title": "Your Dashboard at a Glance",
+	"tour.step.stats.desc": "Today's key metrics — total trends, news count, average score, and early signals.",
+	"tour.step.categories.title": "Category Breakdown",
+	"tour.step.categories.desc": "See how trends are distributed across categories.",
+	"tour.step.early.title": "Early Signals",
+	"tour.step.early.desc": "Catch emerging trends before they go mainstream. Higher bars mean faster growth.",
+	"tour.step.keywords.title": "Trending Keywords",
+	"tour.step.keywords.desc": "Click any keyword to jump to related trends.",
+	"tour.step.hot_trends.title": "Hot Trends",
+	"tour.step.hot_trends.desc": "The top-ranked trends right now. Click any card to see full details.",
+	"tour.step.nav.title": "Explore More",
+	"tour.step.nav.desc": "Visit Trends for the full feed, News for articles, or Content Ideas for AI-powered suggestions."
 }

--- a/frontend/src/lib/i18n/ko.json
+++ b/frontend/src/lib/i18n/ko.json
@@ -426,5 +426,22 @@
 	"settings.behavior.suggested": "AI 추천 가중치",
 	"settings.behavior.apply": "추천 가중치 적용",
 	"settings.behavior.apply_error": "추천 가중치 적용에 실패했습니다.",
-	"settings.behavior.no_data": "아직 활동 데이터가 충분하지 않습니다. 트렌드를 더 탐색해 보세요."
+	"settings.behavior.no_data": "아직 활동 데이터가 충분하지 않습니다. 트렌드를 더 탐색해 보세요.",
+
+	"tour.skip": "건너뛰기",
+	"tour.next": "다음",
+	"tour.prev": "이전",
+	"tour.finish": "확인!",
+	"tour.step.stats.title": "대시보드 한눈에 보기",
+	"tour.step.stats.desc": "오늘의 핵심 지표 — 트렌드 수, 뉴스 수, 평균 스코어, 떠오르는 신호를 확인하세요.",
+	"tour.step.categories.title": "카테고리 분포",
+	"tour.step.categories.desc": "트렌드가 카테고리별로 어떻게 분포되어 있는지 확인하세요.",
+	"tour.step.early.title": "떠오르는 신호",
+	"tour.step.early.desc": "주류가 되기 전에 신흥 트렌드를 포착하세요. 높은 바는 빠른 성장을 의미합니다.",
+	"tour.step.keywords.title": "인기 키워드",
+	"tour.step.keywords.desc": "키워드를 클릭하면 관련 트렌드로 이동합니다.",
+	"tour.step.hot_trends.title": "핫 트렌드",
+	"tour.step.hot_trends.desc": "지금 가장 인기 있는 트렌드입니다. 카드를 클릭하면 상세 정보를 볼 수 있습니다.",
+	"tour.step.nav.title": "더 탐색하기",
+	"tour.step.nav.desc": "트렌드 피드, 뉴스, 콘텐츠 아이디어를 확인해보세요."
 }

--- a/frontend/src/lib/ui/OnboardingTour.svelte
+++ b/frontend/src/lib/ui/OnboardingTour.svelte
@@ -1,0 +1,193 @@
+<script lang="ts">
+	import { t } from 'svelte-i18n';
+	import { onMount } from 'svelte';
+	import { X, ChevronLeft, ChevronRight } from 'lucide-svelte';
+
+	interface TourStep {
+		target: string;
+		titleKey: string;
+		descriptionKey: string;
+		position: 'top' | 'bottom';
+	}
+
+	let { steps }: { steps: TourStep[] } = $props();
+
+	const STORAGE_KEY = 'trendscope_tour_completed';
+	const SPOTLIGHT_PAD = 8;
+
+	let visible = $state(false);
+	let currentStep = $state(0);
+	let tooltipStyle = $state('');
+	let spotlightStyle = $state('');
+	let activeSteps = $state<TourStep[]>([]);
+	let prevTargetEl: HTMLElement | null = null;
+
+	const isLastStep = $derived(currentStep >= activeSteps.length - 1);
+
+	function buildActiveSteps(): TourStep[] {
+		const isMobile = window.innerWidth < 640;
+		return steps.filter((s) => {
+			if (isMobile && s.target === 'nav-links') return false;
+			return document.querySelector(`[data-tour="${s.target}"]`) !== null;
+		});
+	}
+
+	function updatePosition(): void {
+		const step = activeSteps[currentStep];
+		if (!step) return;
+
+		const el = document.querySelector<HTMLElement>(`[data-tour="${step.target}"]`);
+		if (!el) return;
+
+		// Restore previous target
+		if (prevTargetEl && prevTargetEl !== el) {
+			prevTargetEl.style.removeProperty('position');
+			prevTargetEl.style.removeProperty('z-index');
+		}
+
+		// Elevate target above overlay
+		el.style.position = 'relative';
+		el.style.zIndex = '51';
+		prevTargetEl = el;
+
+		const rect = el.getBoundingClientRect();
+
+		// Spotlight cutout
+		spotlightStyle = `top:${rect.top - SPOTLIGHT_PAD}px;left:${rect.left - SPOTLIGHT_PAD}px;width:${rect.width + SPOTLIGHT_PAD * 2}px;height:${rect.height + SPOTLIGHT_PAD * 2}px`;
+
+		// Tooltip position
+		const tooltipW = Math.min(360, window.innerWidth - 32);
+		let left = rect.left + rect.width / 2 - tooltipW / 2;
+		left = Math.max(16, Math.min(left, window.innerWidth - tooltipW - 16));
+
+		if (step.position === 'bottom') {
+			tooltipStyle = `top:${rect.bottom + 12}px;left:${left}px;width:${tooltipW}px`;
+		} else {
+			tooltipStyle = `bottom:${window.innerHeight - rect.top + 12}px;left:${left}px;width:${tooltipW}px`;
+		}
+	}
+
+	function scrollAndPosition(): void {
+		const step = activeSteps[currentStep];
+		if (!step) return;
+		const el = document.querySelector<HTMLElement>(`[data-tour="${step.target}"]`);
+		if (!el) {
+			next();
+			return;
+		}
+		el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+		setTimeout(updatePosition, 400);
+	}
+
+	function next(): void {
+		if (isLastStep) {
+			complete();
+		} else {
+			currentStep++;
+			scrollAndPosition();
+		}
+	}
+
+	function prev(): void {
+		if (currentStep > 0) {
+			currentStep--;
+			scrollAndPosition();
+		}
+	}
+
+	function complete(): void {
+		localStorage.setItem(STORAGE_KEY, 'true');
+		cleanup();
+		visible = false;
+	}
+
+	function cleanup(): void {
+		if (prevTargetEl) {
+			prevTargetEl.style.removeProperty('position');
+			prevTargetEl.style.removeProperty('z-index');
+			prevTargetEl = null;
+		}
+	}
+
+	function handleKeydown(e: KeyboardEvent): void {
+		if (!visible) return;
+		if (e.key === 'Escape') complete();
+		else if (e.key === 'ArrowRight') next();
+		else if (e.key === 'ArrowLeft') prev();
+	}
+
+	onMount(() => {
+		if (localStorage.getItem(STORAGE_KEY)) return;
+
+		const timer = setTimeout(() => {
+			activeSteps = buildActiveSteps();
+			if (activeSteps.length === 0) return;
+			visible = true;
+			scrollAndPosition();
+		}, 500);
+
+		const onResize = (): void => {
+			if (visible) updatePosition();
+		};
+		window.addEventListener('resize', onResize);
+
+		return () => {
+			clearTimeout(timer);
+			window.removeEventListener('resize', onResize);
+			cleanup();
+		};
+	});
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if visible && activeSteps.length > 0}
+	<!-- Backdrop -->
+	<div class="fixed inset-0 z-50 bg-black/50" onclick={complete} role="presentation"></div>
+
+	<!-- Spotlight cutout -->
+	<div
+		class="fixed z-50 rounded-lg ring-4 ring-blue-400/60 pointer-events-none"
+		style={spotlightStyle}
+	></div>
+
+	<!-- Tooltip -->
+	<div class="fixed z-[52] rounded-lg bg-white p-4 shadow-xl" style={tooltipStyle}>
+		<button
+			onclick={complete}
+			class="absolute right-2 top-2 text-gray-400 hover:text-gray-600"
+			aria-label={$t('tour.skip')}
+		>
+			<X size={16} />
+		</button>
+
+		<h3 class="pr-6 text-sm font-semibold text-gray-900">
+			{$t(activeSteps[currentStep].titleKey)}
+		</h3>
+		<p class="mt-1 text-xs leading-relaxed text-gray-600">
+			{$t(activeSteps[currentStep].descriptionKey)}
+		</p>
+
+		<div class="mt-3 flex items-center justify-between">
+			<span class="text-xs text-gray-400">{currentStep + 1} / {activeSteps.length}</span>
+			<div class="flex gap-2">
+				{#if currentStep > 0}
+					<button
+						onclick={prev}
+						class="flex items-center gap-1 rounded-md border border-gray-300 px-3 py-1.5 text-xs text-gray-700 hover:bg-gray-50"
+					>
+						<ChevronLeft size={14} />
+						{$t('tour.prev')}
+					</button>
+				{/if}
+				<button
+					onclick={next}
+					class="flex items-center gap-1 rounded-md bg-blue-600 px-3 py-1.5 text-xs text-white hover:bg-blue-700"
+				>
+					{$t(isLastStep ? 'tour.finish' : 'tour.next')}
+					{#if !isLastStep}<ChevronRight size={14} />{/if}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -7,9 +7,20 @@
 	import { afterNavigate } from '$app/navigation';
 	import { onMount } from 'svelte';
 	import { Menu, X } from 'lucide-svelte';
+	import OnboardingTour from '$lib/ui/OnboardingTour.svelte';
 
 	initI18n();
 	onMount(() => authStore.initialize());
+
+	const TOUR_STEPS = [
+		{ target: 'stat-cards', titleKey: 'tour.step.stats.title', descriptionKey: 'tour.step.stats.desc', position: 'bottom' as const },
+		{ target: 'category-chart', titleKey: 'tour.step.categories.title', descriptionKey: 'tour.step.categories.desc', position: 'bottom' as const },
+		{ target: 'top-keywords', titleKey: 'tour.step.keywords.title', descriptionKey: 'tour.step.keywords.desc', position: 'bottom' as const },
+		{ target: 'early-trends', titleKey: 'tour.step.early.title', descriptionKey: 'tour.step.early.desc', position: 'bottom' as const },
+		{ target: 'hot-trends', titleKey: 'tour.step.hot_trends.title', descriptionKey: 'tour.step.hot_trends.desc', position: 'top' as const },
+		{ target: 'nav-links', titleKey: 'tour.step.nav.title', descriptionKey: 'tour.step.nav.desc', position: 'bottom' as const },
+	];
+	const showTour = $derived($page.url.pathname === '/' && authStore.isAuthenticated && !!authStore.user?.role);
 
 	let { children } = $props();
 
@@ -34,7 +45,7 @@
 				<div class="flex h-16 items-center justify-between">
 					<div class="flex items-center gap-8">
 						<a href="/" class="text-xl font-bold text-gray-900">TrendScope</a>
-						<div class="hidden sm:flex items-center gap-4">
+						<div class="hidden sm:flex items-center gap-4" data-tour="nav-links">
 							<a href="/trends" class="text-sm text-gray-600 hover:text-gray-900">{$t('nav.sidebar.trends')}</a>
 							<a href="/news" class="text-sm text-gray-600 hover:text-gray-900">{$t('nav.sidebar.news')}</a>
 							<a href="/content" class="text-sm text-gray-600 hover:text-gray-900">{$t('nav.content')}</a>
@@ -96,5 +107,9 @@
 		<main class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8">
 			{@render children()}
 		</main>
+
+		{#if showTour}
+			<OnboardingTour steps={TOUR_STEPS} />
+		{/if}
 	</div>
 {/if}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -114,7 +114,7 @@
 	{:else}
 		<!-- Summary Stats -->
 		{#if summary}
-			<div class="grid grid-cols-2 md:grid-cols-4 gap-3 sm:gap-4">
+			<div data-tour="stat-cards" class="grid grid-cols-2 md:grid-cols-4 gap-3 sm:gap-4">
 				<StatCard
 					icon={TrendingUp}
 					iconColor="text-red-500"
@@ -148,7 +148,7 @@
 		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
 			<!-- Category Distribution Donut -->
 			{#if summary && Object.keys(summary.category_counts).length > 0}
-				<div class="rounded-lg border border-gray-200 bg-white p-4 sm:p-5">
+				<div data-tour="category-chart" class="rounded-lg border border-gray-200 bg-white p-4 sm:p-5">
 					<div class="flex items-center gap-2 mb-4">
 						<BarChart3 size={18} class="text-indigo-500" />
 						<h3 class="text-sm font-semibold text-gray-900">
@@ -245,7 +245,7 @@
 
 			<!-- Top Keywords Tag Cloud -->
 			{#if keywordCounts.length > 0}
-				<div class="rounded-lg border border-gray-200 bg-white p-4 sm:p-5">
+				<div data-tour="top-keywords" class="rounded-lg border border-gray-200 bg-white p-4 sm:p-5">
 					<div class="flex items-center gap-2 mb-4">
 						<Hash size={18} class="text-violet-500" />
 						<h3 class="text-sm font-semibold text-gray-900">
@@ -271,7 +271,7 @@
 
 			<!-- Early Trends -->
 			{#if earlyTrends.length > 0}
-				<div class="rounded-lg border border-gray-200 bg-white p-4 sm:p-5">
+				<div data-tour="early-trends" class="rounded-lg border border-gray-200 bg-white p-4 sm:p-5">
 					<div class="flex items-center gap-2 mb-2">
 						<Zap size={18} class="text-amber-500" />
 						<h3 class="text-sm font-semibold text-gray-900">
@@ -317,7 +317,7 @@
 		</div>
 
 		<!-- Hot Trends -->
-		<section>
+		<section data-tour="hot-trends">
 			<div class="flex items-center justify-between mb-3">
 				<div class="flex items-center gap-2">
 					<TrendingUp size={20} class="text-red-500" />


### PR DESCRIPTION
## Summary
- 온보딩 위저드 완료 후 대시보드에서 6단계 인터랙티브 tooltip 투어 표시
- localStorage 기반 1회 표시, 모바일 자동 대응
- spotlight 하이라이트 + 키보드 네비게이션 (Esc/←→)

## Test plan
- [x] pytest 904 passed, 73.73% coverage
- [x] ruff lint/format 통과
- [ ] 브라우저 localStorage 클리어 후 대시보드 접속 → 투어 표시 확인
- [ ] Next/Previous/Skip 동작 확인
- [ ] 완료 후 새로고침 → 투어 미표시 확인
- [ ] 모바일 뷰포트에서 nav-links 스텝 스킵 확인

Closes: #124