### PR TITLE
Fix: API 이미지 crawler 의존성 누락 해결

### DIFF
--- a/requirements/api.txt
+++ b/requirements/api.txt
@@ -9,3 +9,9 @@ email-validator==2.2.0
 pyotp>=2.9.0
 prometheus-fastapi-instrumentator>=6.0.0
 reportlab>=4.0.0
+# burst_job imports burst_crawler → news_crawler chain
+feedparser>=6.0.11
+newspaper3k>=0.2.8
+readability-lxml>=0.8.1
+beautifulsoup4>=4.12.0
+lxml>=5.0.0


### PR DESCRIPTION
## Summary
- burst_job → burst_crawler → news_crawler import 체인에 필요한 crawler 패키지가 api.txt에 누락
- feedparser, newspaper3k, readability-lxml, beautifulsoup4, lxml 추가
- API 컨테이너 시작 시 ModuleNotFoundError 해소

## Test plan
- [x] pytest 904 passed, 73.73% coverage
- [x] docker compose build api → up -d → healthy 확인
- [x] curl http://localhost/api/v1/trends → valid JSON 응답 확인

Closes: #126