### PR TITLE
Feat: kiwipiepy 기반 품사 필터링으로 키워드 추출 정확도 개선

### DIFF
--- a/backend/processor/shared/keyword_extractor.py
+++ b/backend/processor/shared/keyword_extractor.py
@@ -87,9 +87,10 @@ _STOP_WORDS: frozenset[str] = frozenset(
     }
 )
 
-# Korean stop words (common particles / functional words)
+# Korean stop words (common particles / functional words / news boilerplate)
 _KOREAN_STOP_WORDS: frozenset[str] = frozenset(
     {
+        # 기존 — 조사/어미/접속사
         "것이",
         "하는",
         "있는",
@@ -111,8 +112,68 @@ _KOREAN_STOP_WORDS: frozenset[str] = frozenset(
         "따르면",
         "밝혔다",
         "전했다",
+        # 뉴스 빈출 무의미 단어
+        "것으로",
+        "지난",
+        "올해",
+        "오늘",
+        "내년",
+        "최근",
+        "현재",
+        "이후",
+        "가운데",
+        "사이",
+        "가량",
+        "정도",
+        "이상",
+        "미만",
+        "대비",
+        "전년",
+        "분기",
+        "한편",
+        "이날",
+        # 매체/기자 관련
+        "기자",
+        "특파원",
+        "뉴스",
+        "연합뉴스",
+        "한겨레",
+        "매일경제",
+        "조선일보",
+        "중앙일보",
+        "동아일보",
+        "한국경제",
+        "머니투데이",
+        "아시아경제",
+        "헤럴드경제",
     }
 )
+
+# POS tags to keep from kiwipiepy (nouns + English)
+_NOUN_POS_TAGS: frozenset[str] = frozenset({"NNG", "NNP", "NNB", "SL"})
+
+# --- Kiwi singleton ---
+_kiwi_instance: object | None = None
+_kiwi_loaded: bool = False
+
+
+def _get_kiwi() -> object | None:
+    """Lazy-load kiwipiepy Kiwi instance. Returns None if unavailable."""
+    global _kiwi_instance, _kiwi_loaded
+    if not _kiwi_loaded:
+        try:
+            from kiwipiepy import Kiwi  # type: ignore[import-untyped]
+
+            _kiwi_instance = Kiwi()
+            _kiwi_loaded = True
+            logger.info("kiwi_loaded")
+        except ImportError:
+            _kiwi_loaded = True
+            logger.info("kiwi_unavailable_fallback")
+        except Exception as exc:
+            _kiwi_loaded = True
+            logger.warning("kiwi_load_failed", error=str(exc))
+    return _kiwi_instance
 
 
 @dataclass
@@ -171,6 +232,25 @@ def _tokenize_simple(text: str) -> list[str]:
         and t.lower() not in _STOP_WORDS
         and t not in _KOREAN_STOP_WORDS
     ]
+
+
+def _try_kiwi_tokenize(text: str) -> list[str] | None:
+    """Attempt kiwipiepy POS-based tokenization. Returns None if unavailable."""
+    kiwi = _get_kiwi()
+    if kiwi is None:
+        return None
+    try:
+        result = kiwi.tokenize(text)
+        tokens = [
+            token.form
+            for token in result
+            if token.tag in _NOUN_POS_TAGS
+            and _MIN_KEYWORD_LEN <= len(token.form) <= _MAX_KEYWORD_LEN
+        ]
+        return [t for t in tokens if t.lower() not in _STOP_WORDS and t not in _KOREAN_STOP_WORDS]
+    except Exception as exc:
+        logger.warning("kiwi_tokenize_failed", error=str(exc))
+        return None
 
 
 def _try_soynlp_tokenize(text: str) -> list[str] | None:
@@ -245,9 +325,10 @@ def extract_keywords(
     if not text or not text.strip():
         return []
 
-    # Tokenize
+    # Tokenize: kiwi (POS) → soynlp → simple regex
     tokens: list[str] | None = None
-    if use_soynlp:
+    tokens = _try_kiwi_tokenize(text)
+    if tokens is None and use_soynlp:
         tokens = _try_soynlp_tokenize(text)
     if tokens is None:
         tokens = _tokenize_simple(text)

--- a/requirements/processor.txt
+++ b/requirements/processor.txt
@@ -1,6 +1,7 @@
 # Processor service dependencies (ML packages — all lazy-imported with fallbacks)
 -r base.txt
 soynlp>=0.0.493
+kiwipiepy>=0.18.0
 scikit-learn>=1.5.0
 xgboost>=2.0.0
 prophet>=1.1.5

--- a/tests/test_keyword_extractor.py
+++ b/tests/test_keyword_extractor.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
+import pytest
 from backend.processor.shared.keyword_extractor import (
     CorpusStats,
     Keyword,
+    _get_kiwi,
+    _try_kiwi_tokenize,
     extract_keywords,
     reset_corpus_stats,
 )
+
+_kiwi_available = _get_kiwi() is not None
 
 
 class TestExtractKeywords:
@@ -30,7 +37,8 @@ class TestExtractKeywords:
         assert len(result) > 0
         assert all(isinstance(kw, Keyword) for kw in result)
         terms = [kw.term for kw in result]
-        assert "인공지능" in terms
+        # kiwi splits 인공지능 → 인공 + 지능; regex keeps it whole
+        assert "인공지능" in terms or ("인공" in terms and "지능" in terms)
 
     def test_basic_english_extraction(self) -> None:
         text = "artificial intelligence technology artificial intelligence innovation"
@@ -88,3 +96,59 @@ class TestExtractKeywords:
         has_english = any(t.isascii() for t in terms)
         assert has_korean
         assert has_english
+
+
+class TestKiwiPosFiltering:
+    """Tests for kiwipiepy POS-based keyword filtering."""
+
+    def setup_method(self) -> None:
+        reset_corpus_stats()
+
+    @pytest.mark.skipif(not _kiwi_available, reason="kiwipiepy not installed")
+    def test_verb_endings_filtered(self) -> None:
+        """동사/어미 어절이 키워드에서 제거되는지 확인."""
+        text = "경제가 성장하고 있지만 물가도 올랐다 기술이 발전했다"
+        result = extract_keywords(text, use_soynlp=False)
+        terms = [kw.term for kw in result]
+        # 동사/어미 어절은 제외되어야 함
+        verb_endings = {"있지만", "올랐다", "발전했다", "성장하고"}
+        for verb in verb_endings:
+            assert verb not in terms, f"동사/어미 '{verb}'가 키워드에 포함됨"
+
+    def test_nouns_extracted(self) -> None:
+        """명사가 정상 추출되는지 확인."""
+        text = "인공지능 기술과 경제 성장이 화두다 인공지능 경제"
+        result = extract_keywords(text, use_soynlp=False)
+        terms = [kw.term for kw in result]
+        # kiwi가 사용 가능하면 명사 추출, 아니면 regex fallback
+        assert len(terms) > 0
+
+    def test_korean_stopwords_filtered(self) -> None:
+        """확장된 한국어 stopwords가 필터링되는지 확인."""
+        text = "기자 연합뉴스 최근 올해 지난 현재 경제 성장"
+        result = extract_keywords(text, use_soynlp=False)
+        terms = [kw.term for kw in result]
+        stopwords = {"기자", "연합뉴스", "최근", "올해", "지난", "현재"}
+        for sw in stopwords:
+            assert sw not in terms, f"stopword '{sw}'가 키워드에 포함됨"
+
+    def test_kiwi_fallback_to_simple(self) -> None:
+        """kiwi 사용 불가 시 regex fallback 동작 확인."""
+        with patch(
+            "backend.processor.shared.keyword_extractor._get_kiwi",
+            return_value=None,
+        ):
+            text = "인공지능 기술이 빠르게 발전하고 있다 인공지능 혁신"
+            result = extract_keywords(text, use_soynlp=False)
+            assert len(result) > 0
+            terms = [kw.term for kw in result]
+            assert "인공지능" in terms
+
+    @pytest.mark.skipif(not _kiwi_available, reason="kiwipiepy not installed")
+    def test_kiwi_tokenize_returns_nouns(self) -> None:
+        """kiwi 토크나이저가 명사만 반환하는지 직접 확인."""
+        tokens = _try_kiwi_tokenize("경제가 성장하고 기술이 발전했다")
+        assert tokens is not None
+        verb_forms = {"성장하고", "발전했다"}
+        for v in verb_forms:
+            assert v not in tokens, f"동사 '{v}'가 kiwi 토큰에 포함됨"


### PR DESCRIPTION
## Summary
- kiwipiepy POS 태깅 도입하여 명사/고유명사만 키워드로 추출 (기존 regex `[가-힣]{2,}` 대체)
- 토크나이저 우선순위: kiwi → soynlp → simple regex (fallback 체인 유지)
- 한국어 뉴스 빈출 무의미 stopwords 확장 (매체명, 기자, 시간표현 등 20+개)
- 동사/어미 필터링 테스트 5건 추가 (kiwi 미설치 환경은 skipif 처리)

## Test plan
- [x] `pytest tests/test_keyword_extractor.py` — 16건 전체 통과
- [x] `ruff check` / `ruff format` — 클린
- [x] 전체 테스트 907 passed, coverage 73.56%
- [ ] Docker 빌드 시 kiwipiepy 설치 확인
- [ ] 실 뉴스 데이터로 동사/어미 제거 결과 비교

Ref: #134