### PR TITLE
Feat: 클러스터 후처리 정제 — centroid 기반 outlier 분리

### DIFF
--- a/backend/processor/pipeline.py
+++ b/backend/processor/pipeline.py
@@ -23,6 +23,7 @@ from backend.processor.shared.semantic_clusterer import (
     cluster_items,
     compute_cosine_similarity,
     encode_text,
+    refine_clusters,
 )
 from backend.processor.shared.spam_filter import classify_spam
 from backend.processor.shared.text_normalizer import normalize_text
@@ -361,6 +362,7 @@ def _stage_cluster(articles: list[dict[str, Any]]) -> list[Cluster]:
             )
 
         clusters = cluster_items(items)
+        clusters = refine_clusters(clusters)
 
         # Attach original article data to clusters
         article_map = {a.get("url_hash", ""): a for a in articles}

--- a/backend/processor/shared/semantic_clusterer.py
+++ b/backend/processor/shared/semantic_clusterer.py
@@ -226,3 +226,120 @@ def cluster_items(
     )
 
     return clusters
+
+
+# --- Outlier refinement ---
+_OUTLIER_SIGMA: float = 1.0
+
+
+def _compute_centroid(members: list[ClusterItem]) -> list[float] | None:
+    """Compute the mean embedding vector of cluster members."""
+    embeddings = [m.embedding for m in members if m.embedding is not None]
+    if not embeddings:
+        return None
+    dim = len(embeddings[0])
+    centroid = [0.0] * dim
+    for emb in embeddings:
+        for i in range(dim):
+            centroid[i] += emb[i]
+    n = len(embeddings)
+    return [c / n for c in centroid]
+
+
+def _member_similarity(
+    member: ClusterItem,
+    centroid: list[float] | None,
+    rep_keywords: set[str],
+) -> float:
+    """Compute similarity of a member to the cluster centroid/representative."""
+    if centroid is not None and member.embedding is not None:
+        return compute_cosine_similarity(member.embedding, centroid)
+    # Fallback: Jaccard against representative keywords
+    if rep_keywords and member.keywords:
+        return compute_jaccard(member.keywords, rep_keywords)
+    return 1.0  # No data to judge → keep
+
+
+def refine_clusters(
+    clusters: list[Cluster],
+    *,
+    sigma: float = _OUTLIER_SIGMA,
+) -> list[Cluster]:
+    """Remove outlier members from clusters using centroid distance.
+
+    Members with similarity below (mean - sigma * std) are separated
+    into their own single-item clusters.
+
+    Args:
+        clusters: Clusters to refine.
+        sigma: Standard deviation multiplier for cutoff.
+
+    Returns:
+        Refined list of clusters (outliers become singleton clusters).
+    """
+    refined: list[Cluster] = []
+    total_removed = 0
+
+    for cluster in clusters:
+        all_members = [cluster.representative, *cluster.members]
+
+        # Skip singleton clusters
+        if len(all_members) <= 2:
+            refined.append(cluster)
+            continue
+
+        # Compute centroid and representative keywords
+        centroid = _compute_centroid(all_members)
+        rep_keywords = cluster.representative.keywords
+
+        # Compute per-member similarities
+        sims = [_member_similarity(m, centroid, rep_keywords) for m in all_members]
+
+        mean_sim = sum(sims) / len(sims)
+        variance = sum((s - mean_sim) ** 2 for s in sims) / len(sims)
+        std_sim = math.sqrt(variance)
+        cutoff = mean_sim - sigma * std_sim
+
+        # Partition: keep vs outlier
+        keep: list[ClusterItem] = []
+        outliers: list[ClusterItem] = []
+        for member, sim in zip(all_members, sims):  # noqa: B905
+            if sim >= cutoff:
+                keep.append(member)
+            else:
+                outliers.append(member)
+
+        if not outliers:
+            refined.append(cluster)
+            continue
+
+        total_removed += len(outliers)
+
+        # Rebuild cluster with remaining members
+        if keep:
+            new_rep = keep[0]
+            new_cluster = Cluster(
+                cluster_id=cluster.cluster_id,
+                representative=new_rep,
+                members=keep[1:],
+            )
+            refined.append(new_cluster)
+
+        # Outliers become singleton clusters
+        for outlier in outliers:
+            refined.append(
+                Cluster(
+                    cluster_id=f"outlier_{outlier.item_id}",
+                    representative=outlier,
+                )
+            )
+
+    if total_removed > 0:
+        logger.info(
+            "cluster_refinement_complete",
+            outliers_removed=total_removed,
+            clusters_before=len(clusters),
+            clusters_after=len(refined),
+        )
+
+    return refined

--- a/tests/test_semantic_clusterer.py
+++ b/tests/test_semantic_clusterer.py
@@ -13,6 +13,7 @@ from backend.processor.shared.semantic_clusterer import (
     compute_similarity,
     compute_source_similarity,
     compute_temporal_similarity,
+    refine_clusters,
 )
 
 
@@ -212,3 +213,92 @@ class TestClusterItems:
         assert isinstance(cluster, Cluster)
         assert cluster.cluster_id == "cluster_0"
         assert cluster.representative.item_id == "1"
+
+
+class TestRefineClusters:
+    """Tests for refine_clusters outlier removal."""
+
+    def test_refine_removes_outlier(self) -> None:
+        """Outlier with very different embedding is separated."""
+        good_emb = [1.0, 0.0, 0.0]
+        outlier_emb = [0.0, 0.0, 1.0]  # orthogonal → low cosine
+        cluster = Cluster(
+            cluster_id="c0",
+            representative=ClusterItem(
+                item_id="1",
+                text="a",
+                keywords={"경제"},
+                embedding=good_emb,
+            ),
+            members=[
+                ClusterItem(item_id="2", text="b", keywords={"경제"}, embedding=good_emb),
+                ClusterItem(item_id="3", text="c", keywords={"경제"}, embedding=good_emb),
+                ClusterItem(
+                    item_id="outlier",
+                    text="d",
+                    keywords={"스포츠"},
+                    embedding=outlier_emb,
+                ),
+            ],
+        )
+        result = refine_clusters([cluster])
+        # outlier should be separated
+        all_ids = set()
+        for c in result:
+            all_ids.add(c.representative.item_id)
+            for m in c.members:
+                all_ids.add(m.item_id)
+        assert "outlier" in all_ids  # not lost, just separated
+        assert len(result) >= 2  # at least original + outlier singleton
+
+    def test_refine_keeps_good_members(self) -> None:
+        """All similar members stay together."""
+        emb = [1.0, 0.0, 0.0]
+        cluster = Cluster(
+            cluster_id="c0",
+            representative=ClusterItem(
+                item_id="1",
+                text="a",
+                keywords={"경제"},
+                embedding=emb,
+            ),
+            members=[
+                ClusterItem(item_id="2", text="b", keywords={"경제"}, embedding=emb),
+                ClusterItem(item_id="3", text="c", keywords={"경제"}, embedding=emb),
+            ],
+        )
+        result = refine_clusters([cluster])
+        assert len(result) == 1
+        assert result[0].size == 3
+
+    def test_refine_single_item_cluster(self) -> None:
+        """Singleton clusters are unchanged."""
+        cluster = Cluster(
+            cluster_id="c0",
+            representative=ClusterItem(item_id="1", text="a"),
+        )
+        result = refine_clusters([cluster])
+        assert len(result) == 1
+        assert result[0].size == 1
+
+    def test_refine_no_embeddings_fallback(self) -> None:
+        """Without embeddings, Jaccard is used as fallback."""
+        shared_kw = {"경제", "성장", "투자"}
+        outlier_kw = {"스포츠", "야구", "축구"}
+        cluster = Cluster(
+            cluster_id="c0",
+            representative=ClusterItem(
+                item_id="1",
+                text="a",
+                keywords=shared_kw,
+            ),
+            members=[
+                ClusterItem(item_id="2", text="b", keywords=shared_kw),
+                ClusterItem(item_id="3", text="c", keywords=shared_kw),
+                ClusterItem(item_id="outlier", text="d", keywords=outlier_kw),
+            ],
+        )
+        result = refine_clusters([cluster])
+        # outlier has zero keyword overlap → should be separated
+        singleton_ids = {c.representative.item_id for c in result if c.size == 1}
+        assert "outlier" in singleton_ids


### PR DESCRIPTION
## Summary
- `refine_clusters()` 함수 추가: 클러스터링 후 centroid 대비 mean-1σ 미만 멤버를 singleton으로 분리
- embedding 기반 cosine similarity 우선, 없을 시 representative keywords Jaccard fallback
- pipeline Stage 5에서 `cluster_items()` 직후 `refine_clusters()` 자동 호출

## Test plan
- [x] `pytest tests/test_semantic_clusterer.py` — 28건 전체 통과
- [x] `ruff check` / `ruff format` — 클린
- [x] 전체 테스트 908 passed, coverage 73.81%
- [ ] 실 데이터로 outlier 분리 결과 확인

Ref: #136