### PR TITLE
Feat: Stage 4.5 기존 그룹 매칭 시간 윈도우 48h→6h 축소

### DIFF
--- a/backend/processor/pipeline.py
+++ b/backend/processor/pipeline.py
@@ -173,6 +173,7 @@ def _stage_extract_keywords(articles: list[dict[str, Any]]) -> list[dict[str, An
 
 _EXISTING_GROUP_MATCH_THRESHOLD = 0.50
 _EXISTING_GROUP_LIMIT = 500
+_EXISTING_GROUP_WINDOW_HOURS = 6
 
 
 def _jaccard(set_a: set[str], set_b: set[str]) -> float:
@@ -198,10 +199,11 @@ async def _stage_match_existing_groups(
             """
             SELECT id, title, keywords, score, category
             FROM news_group
-            WHERE created_at > now() - interval '48 hours'
+            WHERE created_at > now() - make_interval(hours => $1)
             ORDER BY score DESC
-            LIMIT $1
+            LIMIT $2
             """,
+            _EXISTING_GROUP_WINDOW_HOURS,
             _EXISTING_GROUP_LIMIT,
         )
     except Exception as exc:


### PR DESCRIPTION
## Summary
- Stage 4.5 기존 그룹 매칭 SQL의 시간 범위를 48시간→6시간으로 축소
- 오래된 그룹과의 잘못된 매칭 방지로 클러스터 정확도 향상
- 매직 넘버를 `_EXISTING_GROUP_WINDOW_HOURS` 상수로 추출, SQL 파라미터화

## Test plan
- [x] 전체 테스트 904 passed, coverage 73.63%
- [x] `ruff check` / `ruff format` — 클린
- [ ] 배포 후 기존 그룹 매칭율 모니터링 (매칭 수 감소 예상)

Ref: #138