### PR TITLE
Feat: HDBSCAN 밀도 기반 클러스터링 전환

### DIFF
--- a/backend/processor/shared/semantic_clusterer.py
+++ b/backend/processor/shared/semantic_clusterer.py
@@ -175,23 +175,39 @@ def compute_similarity(a: ClusterItem, b: ClusterItem) -> float:
     )
 
 
-def cluster_items(
+_HDBSCAN_MIN_CLUSTER_SIZE: int = 2
+_HDBSCAN_MIN_ITEMS: int = 3
+
+
+def _pick_representative(
+    members: list[ClusterItem],
+) -> tuple[ClusterItem, list[ClusterItem]]:
+    """Pick the member closest to centroid as representative."""
+    if len(members) == 1:
+        return members[0], []
+
+    centroid = _compute_centroid(members)
+    if centroid is not None:
+        best_idx = 0
+        best_sim = -1.0
+        for i, m in enumerate(members):
+            if m.embedding is not None:
+                sim = compute_cosine_similarity(m.embedding, centroid)
+                if sim > best_sim:
+                    best_sim = sim
+                    best_idx = i
+        rep = members[best_idx]
+        rest = members[:best_idx] + members[best_idx + 1 :]
+        return rep, rest
+
+    return members[0], members[1:]
+
+
+def _cluster_greedy(
     items: list[ClusterItem],
-    *,
-    threshold: float = _DEFAULT_CLUSTER_THRESHOLD,
+    threshold: float,
 ) -> list[Cluster]:
-    """Cluster items using greedy single-linkage with composite similarity.
-
-    Args:
-        items: Items to cluster.
-        threshold: Minimum similarity to join a cluster.
-
-    Returns:
-        List of Cluster objects.
-    """
-    if not items:
-        return []
-
+    """Original greedy single-linkage clustering (fallback)."""
     clusters: list[Cluster] = []
 
     for item in items:
@@ -219,11 +235,108 @@ def cluster_items(
             )
             clusters.append(new_cluster)
 
-    logger.info(
-        "clustering_complete",
-        input_count=len(items),
-        cluster_count=len(clusters),
-    )
+    return clusters
+
+
+def _cluster_hdbscan(items: list[ClusterItem]) -> list[Cluster] | None:
+    """HDBSCAN density-based clustering. Returns None if unavailable."""
+    if len(items) < _HDBSCAN_MIN_ITEMS:
+        return None
+
+    try:
+        from sklearn.cluster import HDBSCAN as SklearnHDBSCAN  # type: ignore[import-untyped]
+    except ImportError:
+        logger.info("hdbscan_unavailable_fallback")
+        return None
+
+    try:
+        # Build pairwise distance matrix
+        n = len(items)
+        dist_matrix = [[0.0] * n for _ in range(n)]
+        for i in range(n):
+            for j in range(i + 1, n):
+                sim = compute_similarity(items[i], items[j])
+                dist = max(0.0, 1.0 - sim)
+                dist_matrix[i][j] = dist
+                dist_matrix[j][i] = dist
+
+        model = SklearnHDBSCAN(
+            min_cluster_size=_HDBSCAN_MIN_CLUSTER_SIZE,
+            metric="precomputed",
+        )
+        labels = model.fit_predict(dist_matrix)
+
+        # Group items by label
+        label_groups: dict[int, list[ClusterItem]] = {}
+        for item, label in zip(items, labels):  # noqa: B905
+            label_groups.setdefault(int(label), []).append(item)
+
+        clusters: list[Cluster] = []
+        cluster_idx = 0
+
+        # Real clusters (label >= 0)
+        for label in sorted(k for k in label_groups if k >= 0):
+            members = label_groups[label]
+            rep, rest = _pick_representative(members)
+            clusters.append(
+                Cluster(
+                    cluster_id=f"cluster_{cluster_idx}",
+                    representative=rep,
+                    members=rest,
+                )
+            )
+            cluster_idx += 1
+
+        # Noise points (label == -1) become singletons
+        for noise_item in label_groups.get(-1, []):
+            clusters.append(
+                Cluster(
+                    cluster_id=f"noise_{cluster_idx}",
+                    representative=noise_item,
+                )
+            )
+            cluster_idx += 1
+
+        return clusters
+    except Exception as exc:
+        logger.warning("hdbscan_clustering_failed", error=str(exc))
+        return None
+
+
+def cluster_items(
+    items: list[ClusterItem],
+    *,
+    threshold: float = _DEFAULT_CLUSTER_THRESHOLD,
+) -> list[Cluster]:
+    """Cluster items using HDBSCAN with greedy single-linkage fallback.
+
+    Args:
+        items: Items to cluster.
+        threshold: Minimum similarity for greedy fallback.
+
+    Returns:
+        List of Cluster objects.
+    """
+    if not items:
+        return []
+
+    # Try HDBSCAN first
+    clusters = _cluster_hdbscan(items)
+    if clusters is None:
+        clusters = _cluster_greedy(items, threshold)
+        logger.info(
+            "clustering_complete",
+            method="greedy",
+            input_count=len(items),
+            cluster_count=len(clusters),
+        )
+    else:
+        logger.info(
+            "clustering_complete",
+            method="hdbscan",
+            input_count=len(items),
+            cluster_count=len(clusters),
+        )
 
     return clusters
 

--- a/tests/test_semantic_clusterer.py
+++ b/tests/test_semantic_clusterer.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
 from backend.processor.shared.semantic_clusterer import (
     Cluster,
     ClusterItem,
+    _cluster_greedy,
     cluster_items,
     compute_cosine_similarity,
     compute_jaccard,
@@ -211,8 +213,208 @@ class TestClusterItems:
         clusters = cluster_items(items)
         cluster = clusters[0]
         assert isinstance(cluster, Cluster)
-        assert cluster.cluster_id == "cluster_0"
         assert cluster.representative.item_id == "1"
+
+
+class TestHdbscanClustering:
+    """Tests for HDBSCAN-based clustering."""
+
+    def test_hdbscan_clusters_similar_items(self) -> None:
+        """Items with identical embeddings should cluster together."""
+        now = datetime.now(timezone.utc)
+        emb_a = [1.0, 0.0, 0.0]
+        emb_b = [0.0, 0.0, 1.0]
+        items = [
+            ClusterItem(
+                item_id="a1",
+                text="economy",
+                keywords={"경제", "성장"},
+                published_at=now,
+                source_type="news",
+                embedding=emb_a,
+            ),
+            ClusterItem(
+                item_id="a2",
+                text="economy",
+                keywords={"경제", "성장"},
+                published_at=now,
+                source_type="news",
+                embedding=emb_a,
+            ),
+            ClusterItem(
+                item_id="a3",
+                text="economy",
+                keywords={"경제", "성장"},
+                published_at=now,
+                source_type="news",
+                embedding=emb_a,
+            ),
+            ClusterItem(
+                item_id="b1",
+                text="sports",
+                keywords={"스포츠", "축구"},
+                published_at=now,
+                source_type="news",
+                embedding=emb_b,
+            ),
+            ClusterItem(
+                item_id="b2",
+                text="sports",
+                keywords={"스포츠", "축구"},
+                published_at=now,
+                source_type="news",
+                embedding=emb_b,
+            ),
+            ClusterItem(
+                item_id="b3",
+                text="sports",
+                keywords={"스포츠", "축구"},
+                published_at=now,
+                source_type="news",
+                embedding=emb_b,
+            ),
+        ]
+        clusters = cluster_items(items)
+        # Should produce at least 2 clusters (economy vs sports)
+        assert len(clusters) >= 2
+        # All items should be accounted for
+        total = sum(c.size for c in clusters)
+        assert total == 6
+
+    def test_hdbscan_separates_dissimilar(self) -> None:
+        """Very different items should not cluster together."""
+        now = datetime.now(timezone.utc)
+        past = now - timedelta(days=30)
+        items = [
+            ClusterItem(
+                item_id="1",
+                text="a",
+                keywords={"경제"},
+                published_at=now,
+                source_type="news",
+                embedding=[1.0, 0.0, 0.0],
+            ),
+            ClusterItem(
+                item_id="2",
+                text="b",
+                keywords={"스포츠"},
+                published_at=past,
+                source_type="blog",
+                embedding=[0.0, 1.0, 0.0],
+            ),
+            ClusterItem(
+                item_id="3",
+                text="c",
+                keywords={"정치"},
+                published_at=past,
+                source_type="sns",
+                embedding=[0.0, 0.0, 1.0],
+            ),
+        ]
+        clusters = cluster_items(items)
+        # All items are dissimilar → likely separate or noise
+        assert len(clusters) >= 2
+
+    def test_hdbscan_all_items_preserved(self) -> None:
+        """No items should be lost during clustering."""
+        now = datetime.now(timezone.utc)
+        items = [
+            ClusterItem(
+                item_id=f"item_{i}",
+                text=f"text {i}",
+                keywords={f"kw{i}"},
+                published_at=now,
+                embedding=[float(i), 0.0, 0.0],
+            )
+            for i in range(5)
+        ]
+        clusters = cluster_items(items)
+        all_ids = set()
+        for c in clusters:
+            all_ids.add(c.representative.item_id)
+            for m in c.members:
+                all_ids.add(m.item_id)
+        assert all_ids == {f"item_{i}" for i in range(5)}
+
+    def test_hdbscan_fallback_few_items(self) -> None:
+        """With < 3 items, falls back to greedy."""
+        now = datetime.now(timezone.utc)
+        emb = [1.0, 0.0, 0.0]
+        items = [
+            ClusterItem(
+                item_id="1",
+                text="a",
+                keywords={"경제"},
+                published_at=now,
+                source_type="news",
+                embedding=emb,
+            ),
+            ClusterItem(
+                item_id="2",
+                text="b",
+                keywords={"경제"},
+                published_at=now,
+                source_type="news",
+                embedding=emb,
+            ),
+        ]
+        clusters = cluster_items(items)
+        assert len(clusters) >= 1
+        total = sum(c.size for c in clusters)
+        assert total == 2
+
+    def test_greedy_fallback_on_import_error(self) -> None:
+        """When HDBSCAN is unavailable, greedy fallback is used."""
+        now = datetime.now(timezone.utc)
+        emb = [1.0, 0.0, 0.0]
+        items = [
+            ClusterItem(
+                item_id=str(i),
+                text="a",
+                keywords={"경제"},
+                published_at=now,
+                source_type="news",
+                embedding=emb,
+            )
+            for i in range(4)
+        ]
+        with patch(
+            "backend.processor.shared.semantic_clusterer._cluster_hdbscan",
+            return_value=None,
+        ):
+            clusters = cluster_items(items)
+            assert len(clusters) >= 1
+            total = sum(c.size for c in clusters)
+            assert total == 4
+
+
+class TestClusterGreedy:
+    """Tests for greedy fallback directly."""
+
+    def test_greedy_similar_items(self) -> None:
+        now = datetime.now(timezone.utc)
+        emb = [1.0, 0.0, 0.0]
+        items = [
+            ClusterItem(
+                item_id="1",
+                text="a",
+                keywords={"경제", "성장"},
+                published_at=now,
+                source_type="news",
+                embedding=emb,
+            ),
+            ClusterItem(
+                item_id="2",
+                text="b",
+                keywords={"경제", "성장", "gdp"},
+                published_at=now,
+                source_type="news",
+                embedding=emb,
+            ),
+        ]
+        clusters = _cluster_greedy(items, threshold=0.3)
+        assert len(clusters) == 1
+        assert clusters[0].size == 2
 
 
 class TestRefineClusters:


### PR DESCRIPTION
## Summary
- 기존 greedy single-linkage → `sklearn.cluster.HDBSCAN`으로 교체 (추가 의존성 없음)
- pairwise composite similarity → distance matrix → HDBSCAN(min_cluster_size=2, metric=precomputed)
- 노이즈 포인트(-1)는 singleton 클러스터로 생성
- centroid 기반 representative 선택 (cosine similarity 최대 멤버)
- 아이템 < 3개 또는 HDBSCAN 실패 시 기존 greedy fallback 유지

## Test plan
- [x] `pytest tests/test_semantic_clusterer.py` — 34건 전체 통과
- [x] `ruff check` / `ruff format` — 클린
- [x] 전체 테스트 917 passed, coverage 73.85%
- [ ] 실 뉴스 데이터로 클러스터 품질 비교 (greedy vs HDBSCAN)

Ref: #140