### PR TITLE
Feat: 키워드 co-occurrence bigram 추출로 클러스터링 정확도 개선

### DIFF
--- a/backend/processor/shared/keyword_extractor.py
+++ b/backend/processor/shared/keyword_extractor.py
@@ -21,6 +21,8 @@ _MAX_KEYWORD_LEN: int = 30
 _DEFAULT_TOP_K: int = 10
 _BM25_K1: float = 1.5
 _BM25_B: float = 0.75
+_BIGRAM_MIN_FREQ: int = 2
+_BIGRAM_SCORE_WEIGHT: float = 0.5
 
 # Korean noun-like pattern (2+ syllable sequences)
 _KOREAN_NOUN_PATTERN: re.Pattern[str] = re.compile(r"[가-힣]{2,}")
@@ -304,11 +306,33 @@ def _compute_bm25(
     return idf * numerator / denominator if denominator > 0 else 0.0
 
 
+def _extract_bigrams(
+    tokens: list[str],
+    *,
+    min_freq: int = _BIGRAM_MIN_FREQ,
+) -> Counter[str]:
+    """Extract bigrams (adjacent token pairs) from token list.
+
+    Args:
+        tokens: List of tokens.
+        min_freq: Minimum frequency to include a bigram.
+
+    Returns:
+        Counter of bigram strings with frequency >= min_freq.
+    """
+    bigrams: Counter[str] = Counter()
+    for i in range(len(tokens) - 1):
+        bigram = f"{tokens[i]}_{tokens[i + 1]}"
+        bigrams[bigram] += 1
+    return Counter({b: c for b, c in bigrams.items() if c >= min_freq})
+
+
 def extract_keywords(
     text: str,
     *,
     top_k: int = _DEFAULT_TOP_K,
     use_soynlp: bool = True,
+    use_bigrams: bool = True,
     corpus: CorpusStats | None = None,
 ) -> list[Keyword]:
     """Extract top-k keywords from text using TF-IDF x BM25 scoring.
@@ -317,6 +341,7 @@ def extract_keywords(
         text: Input text (should be pre-normalized).
         top_k: Number of keywords to return.
         use_soynlp: Attempt soynlp tokenization first.
+        use_bigrams: Include co-occurrence bigrams in keywords.
         corpus: Corpus stats for IDF computation. Uses module-level stats if None.
 
     Returns:
@@ -345,11 +370,22 @@ def extract_keywords(
 
     # Score each unique term: TF-IDF × BM25
     scored: list[Keyword] = []
+    unigram_scores: dict[str, float] = {}
     for term, freq in term_counts.items():
         tf_idf = _compute_tf(term, term_counts, doc_length) * _compute_idf(term, stats)
         bm25 = _compute_bm25(term, term_counts, doc_length, stats)
         combined = tf_idf * bm25
+        unigram_scores[term] = combined
         scored.append(Keyword(term=term, score=combined, frequency=freq))
+
+    # Add bigrams (co-occurrence patterns)
+    if use_bigrams and len(tokens) > 1:
+        bigram_counts = _extract_bigrams(tokens)
+        for bigram, freq in bigram_counts.items():
+            parts = bigram.split("_", 1)
+            avg_score = sum(unigram_scores.get(p, 0.0) for p in parts) / len(parts)
+            bigram_score = avg_score * _BIGRAM_SCORE_WEIGHT
+            scored.append(Keyword(term=bigram, score=bigram_score, frequency=freq))
 
     scored.sort(key=lambda kw: kw.score, reverse=True)
     return scored[:top_k]

--- a/tests/test_keyword_extractor.py
+++ b/tests/test_keyword_extractor.py
@@ -152,3 +152,48 @@ class TestKiwiPosFiltering:
         verb_forms = {"성장하고", "발전했다"}
         for v in verb_forms:
             assert v not in tokens, f"동사 '{v}'가 kiwi 토큰에 포함됨"
+
+
+class TestBigramCooccurrence:
+    """Tests for bigram co-occurrence keyword extraction."""
+
+    def setup_method(self) -> None:
+        reset_corpus_stats()
+
+    def test_bigrams_extracted(self) -> None:
+        """Repeated adjacent token pairs should appear as bigrams."""
+        text = "machine learning machine learning machine learning deep learning"
+        result = extract_keywords(text, use_soynlp=False, top_k=20)
+        terms = [kw.term for kw in result]
+        assert "machine_learning" in terms
+
+    def test_bigrams_min_freq(self) -> None:
+        """Bigrams appearing only once should be excluded."""
+        text = "apple banana cherry date elderberry fig"
+        result = extract_keywords(text, use_soynlp=False, top_k=20)
+        terms = [kw.term for kw in result]
+        # Each bigram appears only once → none should be included
+        bigram_terms = [t for t in terms if "_" in t]
+        assert len(bigram_terms) == 0
+
+    def test_bigrams_disabled(self) -> None:
+        """With use_bigrams=False, no bigrams should appear."""
+        text = "machine learning machine learning machine learning"
+        result = extract_keywords(
+            text,
+            use_soynlp=False,
+            use_bigrams=False,
+            top_k=20,
+        )
+        terms = [kw.term for kw in result]
+        bigram_terms = [t for t in terms if "_" in t]
+        assert len(bigram_terms) == 0
+
+    def test_bigrams_have_scores(self) -> None:
+        """Bigram keywords should have non-zero scores."""
+        text = "python programming python programming python programming"
+        result = extract_keywords(text, use_soynlp=False, top_k=20)
+        bigram_kws = [kw for kw in result if "_" in kw.term]
+        for kw in bigram_kws:
+            assert kw.score > 0
+            assert kw.frequency >= 2


### PR DESCRIPTION
## Summary
- 인접 토큰 쌍(bigram) 추출하여 키워드 목록에 포함 (예: `아이폰_출시`)
- min_freq=2 필터로 노이즈 방지, score는 unigram 평균의 0.5배
- `extract_keywords()`에 `use_bigrams` 파라미터 추가 (기본 True)
- Jaccard/클러스터링에서 bigram 자동 활용 (별도 수정 불필요)

## Test plan
- [x] `pytest tests/test_keyword_extractor.py` — 20건 전체 통과
- [x] `ruff check` / `ruff format` — 클린
- [x] 전체 테스트 921 passed, coverage 73.91%
- [ ] 실 뉴스 데이터로 bigram 포함 키워드 품질 확인

Ref: #142