### PR TITLE
Feat: config 인프라 — DB 설정 테이블·시드·config_loader 구현

### DIFF
--- a/backend/db/seeds/admin_settings.py
+++ b/backend/db/seeds/admin_settings.py
@@ -24,6 +24,38 @@ SEEDS: list[tuple[str, str, str, str]] = [
     ("ai.config", _AI_CONFIG_JSON, _AI_CONFIG_JSON, "AI summarization provider config"),
     ("burst_threshold", "0.75", "0.75", "Burst 트리거 early_trend_score 임계값"),
     ("burst_cooldown_hours", "2", "2", "같은 트렌드 Burst 재트리거 쿨다운(시간)"),
+    # ── 클러스터링 파라미터 ────────────────────────────────────────────────
+    ("cluster.cosine_weight", "0.35", "0.35", "클러스터 코사인 유사도 가중치"),
+    ("cluster.jaccard_weight", "0.40", "0.40", "클러스터 Jaccard 키워드 가중치"),
+    ("cluster.temporal_weight", "0.05", "0.05", "클러스터 시간 근접 가중치"),
+    ("cluster.source_weight", "0.20", "0.20", "클러스터 소스 일치 가중치"),
+    ("cluster.jaccard_early_filter", "0.25", "0.25", "Jaccard 조기 필터 임계값"),
+    ("cluster.threshold", "0.65", "0.65", "클러스터 합산 유사도 임계값"),
+    ("cluster.outlier_sigma", "0.7", "0.7", "클러스터 이상치 제거 시그마"),
+    ("cluster.temporal_decay_hours", "24.0", "24.0", "시간 유사도 감쇠 시간(시간)"),
+    ("cluster.louvain_threshold", "0.70", "0.70", "Louvain 커뮤니티 감지 임계값"),
+    # ── 점수 가중치 (합계 100) ────────────────────────────────────────────
+    ("score.weight_freshness", "25", "25", "점수: 신선도 가중치"),
+    ("score.weight_burst", "25", "25", "점수: 버스트 가중치"),
+    ("score.weight_article_count", "15", "15", "점수: 기사 수 가중치"),
+    ("score.weight_source_diversity", "12", "12", "점수: 소스 다양성 가중치"),
+    ("score.weight_social", "10", "10", "점수: 소셜 시그널 가중치"),
+    ("score.weight_keyword", "8", "8", "점수: 키워드 중요도 가중치"),
+    ("score.weight_velocity", "5", "5", "점수: 속도(velocity) 가중치"),
+    # ── 신선도 감쇠 lambda ────────────────────────────────────────────────
+    ("decay.breaking", "0.10", "0.10", "신선도 감쇠: breaking"),
+    ("decay.politics", "0.04", "0.04", "신선도 감쇠: politics"),
+    ("decay.it", "0.02", "0.02", "신선도 감쇠: it"),
+    ("decay.default", "0.05", "0.05", "신선도 감쇠: default"),
+    # ── 스팸 필터 파라미터 ────────────────────────────────────────────────
+    ("spam.url_ratio_threshold", "0.3", "0.3", "스팸: URL 비율 임계값"),
+    ("spam.keyword_threshold", "3", "3", "스팸: 스팸키워드 개수 임계값"),
+    ("spam.min_content_length", "20", "20", "스팸: 최소 본문 길이"),
+    ("spam.non_trend_min_hits", "2", "2", "비트렌드: 키워드 최소 매칭 수"),
+    # ── 키워드 추출 파라미터 ──────────────────────────────────────────────
+    ("keyword.title_boost", "2.0", "2.0", "키워드: 제목 토큰 가중치"),
+    ("keyword.body_max_chars", "500", "500", "키워드: 본문 최대 처리 글자 수"),
+    ("keyword.top_k", "10", "10", "키워드: 추출 상위 K개"),
 ]
 
 

--- a/backend/db/seeds/category_keywords.py
+++ b/backend/db/seeds/category_keywords.py
@@ -1,0 +1,150 @@
+"""카테고리 분류 키워드 시드 — news_crawler.py 카테고리 재분류에 사용."""
+
+from __future__ import annotations
+
+import asyncpg
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+# (keyword, category, weight)
+_CATEGORY_KEYWORDS: list[tuple[str, str, float]] = [
+    # ── sports ──────────────────────────────────────────────────────────
+    ("축구", "sports", 1.5),
+    ("야구", "sports", 1.5),
+    ("농구", "sports", 1.5),
+    ("배구", "sports", 1.2),
+    ("선수", "sports", 1.0),
+    ("감독", "sports", 1.0),
+    ("경기", "sports", 1.0),
+    ("리그", "sports", 1.2),
+    ("골", "sports", 1.0),
+    ("우승", "sports", 1.2),
+    ("올림픽", "sports", 1.5),
+    ("월드컵", "sports", 1.5),
+    ("K리그", "sports", 2.0),
+    ("MLB", "sports", 1.5),
+    ("NBA", "sports", 1.5),
+    ("EPL", "sports", 1.5),
+    ("챔피언스리그", "sports", 1.5),
+    ("국가대표", "sports", 1.3),
+    ("득점", "sports", 1.0),
+    ("승리", "sports", 1.0),
+    # ── tech ────────────────────────────────────────────────────────────
+    ("반도체", "tech", 1.5),
+    ("AI", "tech", 1.5),
+    ("인공지능", "tech", 1.5),
+    ("스타트업", "tech", 1.2),
+    ("앱", "tech", 1.0),
+    ("게임", "tech", 1.0),
+    ("소프트웨어", "tech", 1.2),
+    ("플랫폼", "tech", 1.0),
+    ("클라우드", "tech", 1.2),
+    ("코딩", "tech", 1.0),
+    ("데이터센터", "tech", 1.3),
+    ("GPU", "tech", 1.5),
+    ("LLM", "tech", 1.5),
+    ("챗봇", "tech", 1.2),
+    ("자율주행", "tech", 1.3),
+    ("메타버스", "tech", 1.2),
+    ("블록체인", "tech", 1.2),
+    ("배터리", "tech", 1.2),
+    ("로봇", "tech", 1.2),
+    # ── economy ─────────────────────────────────────────────────────────
+    ("주가", "economy", 1.5),
+    ("코스피", "economy", 2.0),
+    ("코스닥", "economy", 2.0),
+    ("금리", "economy", 1.5),
+    ("환율", "economy", 1.5),
+    ("GDP", "economy", 1.5),
+    ("실적", "economy", 1.2),
+    ("증시", "economy", 1.5),
+    ("채권", "economy", 1.3),
+    ("인플레이션", "economy", 1.3),
+    ("투자", "economy", 1.0),
+    ("물가", "economy", 1.3),
+    ("수출", "economy", 1.2),
+    ("무역", "economy", 1.2),
+    ("경기침체", "economy", 1.5),
+    ("부동산", "economy", 1.3),
+    ("금융", "economy", 1.2),
+    # ── entertainment ────────────────────────────────────────────────────
+    ("드라마", "entertainment", 1.5),
+    ("영화", "entertainment", 1.5),
+    ("아이돌", "entertainment", 1.5),
+    ("배우", "entertainment", 1.2),
+    ("콘서트", "entertainment", 1.3),
+    ("앨범", "entertainment", 1.3),
+    ("유튜브", "entertainment", 1.0),
+    ("웹툰", "entertainment", 1.2),
+    ("OTT", "entertainment", 1.3),
+    ("뮤직비디오", "entertainment", 1.3),
+    ("K팝", "entertainment", 1.5),
+    ("넷플릭스", "entertainment", 1.3),
+    ("시청률", "entertainment", 1.2),
+    ("음원", "entertainment", 1.2),
+    ("팬덤", "entertainment", 1.2),
+    # ── science ──────────────────────────────────────────────────────────
+    ("연구", "science", 1.0),
+    ("논문", "science", 1.5),
+    ("우주", "science", 1.3),
+    ("실험", "science", 1.2),
+    ("임상", "science", 1.5),
+    ("발견", "science", 1.0),
+    ("특허", "science", 1.3),
+    ("NASA", "science", 1.5),
+    ("백신", "science", 1.5),
+    ("유전자", "science", 1.3),
+    ("기후변화", "science", 1.3),
+    ("탄소중립", "science", 1.2),
+    # ── politics ─────────────────────────────────────────────────────────
+    ("국회", "politics", 1.5),
+    ("대통령", "politics", 1.5),
+    ("정부", "politics", 1.2),
+    ("여당", "politics", 1.3),
+    ("야당", "politics", 1.3),
+    ("선거", "politics", 1.5),
+    ("법안", "politics", 1.2),
+    ("정책", "politics", 1.0),
+    ("국무총리", "politics", 1.5),
+    ("장관", "politics", 1.2),
+    ("외교", "politics", 1.2),
+    ("UN", "politics", 1.2),
+    # ── society ──────────────────────────────────────────────────────────
+    ("사건", "society", 1.0),
+    ("사고", "society", 1.0),
+    ("범죄", "society", 1.2),
+    ("교육", "society", 1.0),
+    ("복지", "society", 1.0),
+    ("환경", "society", 1.0),
+    ("인구", "society", 1.0),
+    ("고령화", "society", 1.2),
+    ("저출산", "society", 1.2),
+    ("육아", "society", 1.0),
+]
+
+
+async def seed_category_keywords(conn: asyncpg.Connection) -> None:
+    """category_keyword 테이블에 시드 데이터 삽입."""
+    inserted = 0
+
+    for keyword, category, weight in _CATEGORY_KEYWORDS:
+        result = await conn.fetchval(
+            """
+            INSERT INTO category_keyword (keyword, category, weight, locale)
+            VALUES ($1, $2, $3, 'ko')
+            ON CONFLICT (keyword, category) DO NOTHING
+            RETURNING id
+            """,
+            keyword,
+            category,
+            weight,
+        )
+        if result:
+            inserted += 1
+
+    logger.info(
+        "category_keywords_seeded",
+        inserted=inserted,
+        total=len(_CATEGORY_KEYWORDS),
+    )

--- a/backend/db/seeds/filter_keywords.py
+++ b/backend/db/seeds/filter_keywords.py
@@ -1,0 +1,91 @@
+"""필터 키워드 시드 — spam_filter.py 하드코딩에서 이전 + 부고/비트렌드 신규 추가."""
+
+from __future__ import annotations
+
+import asyncpg
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+# (keyword, category, confidence)
+_FILTER_KEYWORDS: list[tuple[str, str, float]] = [
+    # 광고/홍보 (기존 _SPAM_KEYWORDS에서 이전)
+    ("광고", "ad", 1.0),
+    ("홍보", "ad", 1.0),
+    ("무료", "ad", 0.8),
+    ("할인", "ad", 0.8),
+    ("쿠폰", "ad", 0.9),
+    ("이벤트", "ad", 0.7),
+    ("당첨", "ad", 0.9),
+    ("대출", "ad", 0.9),
+    ("카지노", "gambling", 1.0),
+    ("도박", "gambling", 1.0),
+    ("슬롯", "gambling", 1.0),
+    ("바카라", "gambling", 1.0),
+    ("토토", "gambling", 1.0),
+    ("베팅", "gambling", 0.9),
+    ("성인", "adult", 0.9),
+    ("만남", "adult", 0.8),
+    ("채팅", "adult", 0.7),
+    ("부업", "ad", 0.9),
+    ("재택", "ad", 0.7),
+    ("수익", "ad", 0.7),
+    ("클릭", "ad", 0.8),
+    ("지금바로", "ad", 0.9),
+    ("한정", "ad", 0.7),
+    # 영어 스팸 (기존 이전)
+    ("buy now", "ad", 1.0),
+    ("free money", "ad", 1.0),
+    ("click here", "ad", 1.0),
+    ("limited offer", "ad", 0.9),
+    ("casino", "gambling", 1.0),
+    ("gambling", "gambling", 1.0),
+    ("lottery", "gambling", 0.9),
+    ("prize", "ad", 0.8),
+    ("viagra", "adult", 1.0),
+    ("cialis", "adult", 1.0),
+    ("weight loss", "ad", 0.8),
+    # 부고/비트렌드 (신규 — 이게 핵심)
+    ("부고", "obituary", 1.0),
+    ("訃告", "obituary", 1.0),
+    ("서거", "obituary", 1.0),
+    ("별세", "obituary", 1.0),
+    ("추도", "obituary", 1.0),
+    ("조문", "obituary", 0.9),
+    ("영결식", "obituary", 1.0),
+    ("빈소", "obituary", 1.0),
+    ("장례식", "obituary", 1.0),
+    ("사망진단", "obituary", 1.0),
+    ("부음", "obituary", 1.0),
+    ("향년", "obituary", 1.0),
+    ("작고", "obituary", 1.0),
+    ("타계", "obituary", 1.0),
+    ("유족", "obituary", 0.9),
+    ("발인", "obituary", 1.0),
+]
+
+
+async def seed_filter_keywords(conn: asyncpg.Connection) -> None:
+    """filter_keyword 테이블에 시드 데이터 삽입."""
+    inserted = 0
+
+    for keyword, category, confidence in _FILTER_KEYWORDS:
+        result = await conn.fetchval(
+            """
+            INSERT INTO filter_keyword (keyword, category, source, confidence)
+            VALUES ($1, $2, 'system', $3)
+            ON CONFLICT (keyword) DO NOTHING
+            RETURNING id
+            """,
+            keyword,
+            category,
+            confidence,
+        )
+        if result:
+            inserted += 1
+
+    logger.info(
+        "filter_keywords_seeded",
+        inserted=inserted,
+        total=len(_FILTER_KEYWORDS),
+    )

--- a/backend/db/seeds/stopwords.py
+++ b/backend/db/seeds/stopwords.py
@@ -1,0 +1,271 @@
+"""불용어 시드 데이터 — keyword_extractor.py 하드코딩에서 이전 + 신규 추가."""
+
+from __future__ import annotations
+
+import asyncpg
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+# 한국어 불용어 — 기존 _KOREAN_STOP_WORDS 전체 + 신규
+_KO_WORDS: list[str] = [
+    # 조사/어미/접속사
+    "것이",
+    "하는",
+    "있는",
+    "하고",
+    "에서",
+    "으로",
+    "이다",
+    "했다",
+    "되는",
+    "하며",
+    "그리고",
+    "또한",
+    "이를",
+    "통해",
+    "이번",
+    "대한",
+    "위해",
+    "관련",
+    "따르면",
+    "밝혔다",
+    "전했다",
+    # 뉴스 빈출 무의미 단어
+    "것으로",
+    "지난",
+    "올해",
+    "오늘",
+    "내년",
+    "최근",
+    "현재",
+    "이후",
+    "가운데",
+    "사이",
+    "가량",
+    "정도",
+    "이상",
+    "미만",
+    "대비",
+    "전년",
+    "분기",
+    "한편",
+    "이날",
+    # 매체/기자
+    "기자",
+    "특파원",
+    "뉴스",
+    "연합뉴스",
+    "한겨레",
+    "매일경제",
+    "조선일보",
+    "중앙일보",
+    "동아일보",
+    "한국경제",
+    "머니투데이",
+    "아시아경제",
+    "헤럴드경제",
+    # 월/분기 (신규 — "12월"만 같은 이유로 클러스터링 방지)
+    "1월",
+    "2월",
+    "3월",
+    "4월",
+    "5월",
+    "6월",
+    "7월",
+    "8월",
+    "9월",
+    "10월",
+    "11월",
+    "12월",
+    "1분기",
+    "2분기",
+    "3분기",
+    "4분기",
+    "상반기",
+    "하반기",
+    # 시간 표현 (신규)
+    "연도",
+    "기간",
+    "당일",
+    "전날",
+    "다음날",
+    "내달",
+    "다음달",
+    # 뉴스 보일러플레이트 (신규)
+    "보도",
+    "취재",
+    "단독",
+    "속보",
+    "긴급",
+    "업데이트",
+    "확인",
+    "발표",
+    "입장",
+    "해명",
+    "논평",
+    "공식",
+    "관계자",
+    "측에따르면",
+    # 수량/비율 (신규)
+    "억원",
+    "조원",
+    "만원",
+    "달러",
+    "퍼센트",
+    "배증",
+    "감소",
+    "증가",
+]
+
+# 영어 불용어 — 기존 _STOP_WORDS 전체
+_EN_WORDS: list[str] = [
+    "the",
+    "a",
+    "an",
+    "and",
+    "or",
+    "but",
+    "in",
+    "on",
+    "at",
+    "to",
+    "for",
+    "of",
+    "with",
+    "is",
+    "are",
+    "was",
+    "were",
+    "be",
+    "been",
+    "being",
+    "have",
+    "has",
+    "had",
+    "do",
+    "does",
+    "did",
+    "will",
+    "would",
+    "could",
+    "should",
+    "may",
+    "might",
+    "shall",
+    "can",
+    "this",
+    "that",
+    "these",
+    "those",
+    "it",
+    "its",
+    "he",
+    "she",
+    "they",
+    "we",
+    "you",
+    "i",
+    "am",
+    "from",
+    "by",
+    "about",
+    "into",
+    "through",
+    "during",
+    "before",
+    "after",
+    "above",
+    "below",
+    "between",
+    "not",
+    "no",
+    "nor",
+    "so",
+    "yet",
+    "both",
+    "either",
+    "each",
+    "few",
+    "more",
+    "most",
+    "other",
+    "some",
+    "such",
+    "than",
+    "too",
+    "very",
+    "just",
+    "only",
+    "also",
+    "what",
+    "which",
+    "who",
+    "whom",
+    "whose",
+    "when",
+    "where",
+    "why",
+    "how",
+    "all",
+    "any",
+    "because",
+    "if",
+    "while",
+    "although",
+    "though",
+    "since",
+    "until",
+    "unless",
+    "therefore",
+    "however",
+    "additionally",
+    "moreover",
+    "furthermore",
+    "consequently",
+    "nevertheless",
+    "also",
+    "its",
+    "his",
+    "her",
+]
+
+
+async def seed_stopwords(conn: asyncpg.Connection) -> None:
+    """stopword 테이블에 시드 데이터 삽입."""
+    ko_count = 0
+    en_count = 0
+
+    for word in _KO_WORDS:
+        result = await conn.fetchval(
+            """
+            INSERT INTO stopword (word, locale, source)
+            VALUES ($1, 'ko', 'system')
+            ON CONFLICT (word, locale) DO NOTHING
+            RETURNING id
+            """,
+            word,
+        )
+        if result:
+            ko_count += 1
+
+    for word in _EN_WORDS:
+        result = await conn.fetchval(
+            """
+            INSERT INTO stopword (word, locale, source)
+            VALUES ($1, 'en', 'system')
+            ON CONFLICT (word, locale) DO NOTHING
+            RETURNING id
+            """,
+            word,
+        )
+        if result:
+            en_count += 1
+
+    logger.info(
+        "stopwords_seeded",
+        ko_inserted=ko_count,
+        en_inserted=en_count,
+        ko_total=len(_KO_WORDS),
+        en_total=len(_EN_WORDS),
+    )

--- a/backend/processor/shared/config_loader.py
+++ b/backend/processor/shared/config_loader.py
@@ -1,0 +1,230 @@
+"""DB/Redis 기반 설정 로더 — 알고리즘 파라미터, 불용어, 필터 키워드, 카테고리 키워드.
+
+모든 알고리즘 모듈은 하드코딩 대신 이 모듈을 통해 설정을 로드한다.
+(RULE 18: Redis 캐시 적극 활용)
+"""
+
+from __future__ import annotations
+
+import json
+
+import asyncpg
+import structlog
+
+from backend.processor.shared.cache_manager import delete_cached, get_cached, set_cached
+
+logger = structlog.get_logger(__name__)
+
+# ── 캐시 TTL ────────────────────────────────────────────────────────────────
+_SETTING_TTL = 300  # 5분
+_STOPWORDS_TTL = 600  # 10분
+_FILTER_KW_TTL = 600  # 10분
+_CATEGORY_KW_TTL = 600  # 10분
+
+# ── 캐시 키 패턴 ─────────────────────────────────────────────────────────────
+_KEY_SETTING = "config:setting:{key}"
+_KEY_STOPWORDS = "config:stopwords:{locale}"
+_KEY_FILTER_KW = "config:filter_kw:{category}"
+_KEY_CATEGORY_KW = "config:category_kw"
+
+
+async def get_setting(
+    pool: asyncpg.Pool,
+    key: str,
+    default: float | str | int,
+) -> float | str | int:
+    """admin_settings에서 값 로드. Redis 5분 캐시.
+
+    타입은 default 값의 타입 기준으로 자동 캐스팅.
+    DB/캐시 오류 시 default 반환.
+    """
+    cache_key = _KEY_SETTING.format(key=key)
+    try:
+        cached = await get_cached(cache_key)
+        if cached is not None:
+            raw = cached.decode() if isinstance(cached, bytes) else cached
+            return _cast(raw, default)
+    except Exception as exc:
+        logger.warning("config_cache_read_failed", key=key, error=str(exc))
+
+    try:
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT value FROM admin_settings WHERE key = $1",
+                key,
+            )
+        if row is None:
+            logger.debug("config_setting_not_found", key=key, using_default=default)
+            return default
+
+        raw_value = row["value"]
+        # admin_settings.value는 JSONB — 문자열 값은 '"text"' 형태로 저장됨
+        if isinstance(raw_value, str):
+            try:
+                raw_value = json.loads(raw_value)
+            except (ValueError, TypeError):
+                pass
+        value = _cast(str(raw_value), default)
+        await set_cached(cache_key, str(value).encode(), _SETTING_TTL)
+        return value
+
+    except Exception as exc:
+        logger.error("config_setting_load_failed", key=key, error=str(exc))
+        return default
+
+
+def _cast(raw: str, default: float | str | int) -> float | str | int:
+    """default 타입 기준으로 raw 문자열을 캐스팅."""
+    try:
+        if isinstance(default, float):
+            return float(raw)
+        if isinstance(default, int):
+            return int(float(raw))  # "2.0" → 2
+        return str(raw)
+    except (ValueError, TypeError):
+        return default
+
+
+async def get_stopwords(pool: asyncpg.Pool, locale: str = "ko") -> frozenset[str]:
+    """stopword 테이블(is_active=TRUE)에서 로드. Redis 10분 캐시."""
+    cache_key = _KEY_STOPWORDS.format(locale=locale)
+    try:
+        cached = await get_cached(cache_key)
+        if cached is not None:
+            words = json.loads(cached.decode() if isinstance(cached, bytes) else cached)
+            return frozenset(words)
+    except Exception as exc:
+        logger.warning("stopwords_cache_read_failed", locale=locale, error=str(exc))
+
+    try:
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT word FROM stopword WHERE locale = $1 AND is_active = TRUE",
+                locale,
+            )
+        words = [r["word"] for r in rows]
+        await set_cached(cache_key, json.dumps(words).encode(), _STOPWORDS_TTL)
+        logger.debug("stopwords_loaded", locale=locale, count=len(words))
+        return frozenset(words)
+
+    except Exception as exc:
+        logger.error("stopwords_load_failed", locale=locale, error=str(exc))
+        return frozenset()
+
+
+async def get_filter_keywords(
+    pool: asyncpg.Pool,
+    category: str | None = None,
+) -> frozenset[str]:
+    """filter_keyword 테이블(is_active=TRUE)에서 로드. Redis 10분 캐시.
+
+    category=None → 전체 활성 키워드 반환.
+    category='obituary' → 해당 카테고리만 반환.
+    """
+    cache_key = _KEY_FILTER_KW.format(category=category or "all")
+    try:
+        cached = await get_cached(cache_key)
+        if cached is not None:
+            keywords = json.loads(cached.decode() if isinstance(cached, bytes) else cached)
+            return frozenset(keywords)
+    except Exception as exc:
+        logger.warning("filter_kw_cache_read_failed", category=category, error=str(exc))
+
+    try:
+        async with pool.acquire() as conn:
+            if category is not None:
+                rows = await conn.fetch(
+                    """
+                    SELECT keyword FROM filter_keyword
+                    WHERE category = $1 AND is_active = TRUE
+                    """,
+                    category,
+                )
+            else:
+                rows = await conn.fetch("SELECT keyword FROM filter_keyword WHERE is_active = TRUE")
+        keywords = [r["keyword"] for r in rows]
+        await set_cached(cache_key, json.dumps(keywords).encode(), _FILTER_KW_TTL)
+        logger.debug("filter_keywords_loaded", category=category, count=len(keywords))
+        return frozenset(keywords)
+
+    except Exception as exc:
+        logger.error("filter_keywords_load_failed", category=category, error=str(exc))
+        return frozenset()
+
+
+async def get_category_keywords(
+    pool: asyncpg.Pool,
+) -> dict[str, list[tuple[str, float]]]:
+    """category_keyword 테이블(is_active=TRUE)에서 로드. Redis 10분 캐시.
+
+    Returns:
+        {category: [(keyword, weight), ...]} 형태.
+    """
+    try:
+        cached = await get_cached(_KEY_CATEGORY_KW)
+        if cached is not None:
+            return json.loads(cached.decode() if isinstance(cached, bytes) else cached)
+    except Exception as exc:
+        logger.warning("category_kw_cache_read_failed", error=str(exc))
+
+    try:
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT keyword, category, weight
+                FROM category_keyword
+                WHERE is_active = TRUE
+                ORDER BY category, weight DESC
+                """
+            )
+        result: dict[str, list[tuple[str, float]]] = {}
+        for row in rows:
+            cat = row["category"]
+            if cat not in result:
+                result[cat] = []
+            result[cat].append((row["keyword"], float(row["weight"])))
+
+        await set_cached(_KEY_CATEGORY_KW, json.dumps(result).encode(), _CATEGORY_KW_TTL)
+        logger.debug("category_keywords_loaded", categories=list(result.keys()))
+        return result
+
+    except Exception as exc:
+        logger.error("category_keywords_load_failed", error=str(exc))
+        return {}
+
+
+async def invalidate_cache(prefix: str) -> None:
+    """어드민 변경 시 관련 캐시 키 무효화.
+
+    prefix:
+        'setting:{key}' → 특정 설정 키 하나
+        'stopwords'     → 전체 불용어 (ko + en)
+        'filter_kw'     → 전체 필터 키워드
+        'category_kw'   → 카테고리 키워드 전체
+    """
+    try:
+        if prefix.startswith("setting:"):
+            key = prefix.split("setting:")[-1]
+            await delete_cached(_KEY_SETTING.format(key=key))
+            logger.info("config_cache_invalidated", cache_key=prefix)
+
+        elif prefix == "stopwords":
+            for locale in ("ko", "en"):
+                await delete_cached(_KEY_STOPWORDS.format(locale=locale))
+            logger.info("stopwords_cache_invalidated")
+
+        elif prefix == "filter_kw":
+            # 카테고리별 + 전체 캐시 모두 삭제
+            for cat in ("ad", "gambling", "adult", "obituary", "irrelevant", "custom", "all"):
+                await delete_cached(_KEY_FILTER_KW.format(category=cat))
+            logger.info("filter_kw_cache_invalidated")
+
+        elif prefix == "category_kw":
+            await delete_cached(_KEY_CATEGORY_KW)
+            logger.info("category_kw_cache_invalidated")
+
+        else:
+            logger.warning("config_invalidate_unknown_prefix", prefix=prefix)
+
+    except Exception as exc:
+        logger.error("config_cache_invalidate_failed", prefix=prefix, error=str(exc))

--- a/migrations/023_config_tables.py
+++ b/migrations/023_config_tables.py
@@ -1,0 +1,75 @@
+"""023_config_tables — stopword, filter_keyword, category_keyword 테이블 생성."""
+
+from __future__ import annotations
+
+import asyncpg
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+VERSION = "023"
+DESCRIPTION = "Create stopword, filter_keyword, category_keyword tables"
+
+
+async def up(conn: asyncpg.Connection) -> None:
+    """Create config management tables."""
+    # 불용어 관리
+    await conn.execute("""
+        CREATE TABLE IF NOT EXISTS stopword (
+            id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            word       TEXT NOT NULL,
+            locale     TEXT NOT NULL DEFAULT 'ko',
+            is_active  BOOLEAN NOT NULL DEFAULT TRUE,
+            source     TEXT NOT NULL DEFAULT 'system',
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+    """)
+    await conn.execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_stopword_word_locale
+        ON stopword (word, locale)
+    """)
+
+    # 필터 키워드 (스팸/비트렌드 통합)
+    await conn.execute("""
+        CREATE TABLE IF NOT EXISTS filter_keyword (
+            id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            keyword    TEXT NOT NULL,
+            category   TEXT NOT NULL,
+            source     TEXT NOT NULL DEFAULT 'system',
+            is_active  BOOLEAN NOT NULL DEFAULT TRUE,
+            confidence FLOAT NOT NULL DEFAULT 1.0,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+    """)
+    await conn.execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_filter_keyword
+        ON filter_keyword (keyword)
+    """)
+
+    # 카테고리 분류 키워드
+    await conn.execute("""
+        CREATE TABLE IF NOT EXISTS category_keyword (
+            id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            keyword    TEXT NOT NULL,
+            category   TEXT NOT NULL,
+            weight     FLOAT NOT NULL DEFAULT 1.0,
+            locale     TEXT NOT NULL DEFAULT 'ko',
+            is_active  BOOLEAN NOT NULL DEFAULT TRUE,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+    """)
+    await conn.execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_category_keyword
+        ON category_keyword (keyword, category)
+    """)
+
+    logger.info("migration_023_complete")
+
+
+async def down(conn: asyncpg.Connection) -> None:
+    """Drop config tables."""
+    await conn.execute("DROP TABLE IF EXISTS category_keyword CASCADE")
+    await conn.execute("DROP TABLE IF EXISTS filter_keyword CASCADE")
+    await conn.execute("DROP TABLE IF EXISTS stopword CASCADE")
+    logger.info("migration_023_reverted")

--- a/migrations/024_burst_score.py
+++ b/migrations/024_burst_score.py
@@ -1,0 +1,34 @@
+"""024_burst_score — news_group에 burst_score 컬럼 추가."""
+
+from __future__ import annotations
+
+import asyncpg
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+VERSION = "024"
+DESCRIPTION = "Add burst_score column to news_group"
+
+
+async def up(conn: asyncpg.Connection) -> None:
+    """Add burst_score column and index."""
+    await conn.execute("""
+        ALTER TABLE news_group
+        ADD COLUMN IF NOT EXISTS burst_score FLOAT NOT NULL DEFAULT 0.0
+    """)
+    await conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_news_group_burst_score
+        ON news_group (burst_score DESC)
+    """)
+    logger.info("migration_024_complete")
+
+
+async def down(conn: asyncpg.Connection) -> None:
+    """Remove burst_score column."""
+    await conn.execute("DROP INDEX IF EXISTS idx_news_group_burst_score")
+    await conn.execute("""
+        ALTER TABLE news_group
+        DROP COLUMN IF EXISTS burst_score
+    """)
+    logger.info("migration_024_reverted")

--- a/migrations/025_seed_config_data.py
+++ b/migrations/025_seed_config_data.py
@@ -1,0 +1,95 @@
+"""025_seed_config_data — stopword, filter_keyword, category_keyword, admin_settings 시드."""
+
+from __future__ import annotations
+
+import asyncpg
+import structlog
+from backend.db.seeds.category_keywords import seed_category_keywords
+from backend.db.seeds.filter_keywords import seed_filter_keywords
+from backend.db.seeds.stopwords import seed_stopwords
+
+logger = structlog.get_logger(__name__)
+
+VERSION = "025"
+DESCRIPTION = "Seed stopwords, filter_keywords, category_keywords, admin_settings algorithm params"
+
+# admin_settings 추가 시드 (클러스터링·점수·스팸·키워드 파라미터)
+_ADMIN_SETTINGS: list[tuple[str, str, str, str]] = [
+    # 클러스터링
+    ("cluster.cosine_weight",        "0.35", "0.35", "클러스터 코사인 유사도 가중치"),
+    ("cluster.jaccard_weight",       "0.40", "0.40", "클러스터 Jaccard 키워드 가중치"),
+    ("cluster.temporal_weight",      "0.05", "0.05", "클러스터 시간 근접 가중치"),
+    ("cluster.source_weight",        "0.20", "0.20", "클러스터 소스 일치 가중치"),
+    ("cluster.jaccard_early_filter", "0.25", "0.25", "Jaccard 조기 필터 임계값"),
+    ("cluster.threshold",            "0.65", "0.65", "클러스터 합산 유사도 임계값"),
+    ("cluster.outlier_sigma",        "0.7",  "0.7",  "클러스터 이상치 제거 시그마"),
+    ("cluster.temporal_decay_hours", "24.0", "24.0", "시간 유사도 감쇠 시간(시간)"),
+    ("cluster.louvain_threshold",    "0.70", "0.70", "Louvain 커뮤니티 감지 임계값"),
+    # 점수 가중치 (합계 100)
+    ("score.weight_freshness",        "25", "25", "점수: 신선도 가중치"),
+    ("score.weight_burst",            "25", "25", "점수: 버스트 가중치"),
+    ("score.weight_article_count",    "15", "15", "점수: 기사 수 가중치"),
+    ("score.weight_source_diversity", "12", "12", "점수: 소스 다양성 가중치"),
+    ("score.weight_social",           "10", "10", "점수: 소셜 시그널 가중치"),
+    ("score.weight_keyword",           "8",  "8", "점수: 키워드 중요도 가중치"),
+    ("score.weight_velocity",          "5",  "5", "점수: 속도(velocity) 가중치"),
+    # 신선도 감쇠 lambda
+    ("decay.breaking", "0.10", "0.10", "신선도 감쇠: breaking"),
+    ("decay.politics", "0.04", "0.04", "신선도 감쇠: politics"),
+    ("decay.it",       "0.02", "0.02", "신선도 감쇠: it"),
+    ("decay.default",  "0.05", "0.05", "신선도 감쇠: default"),
+    # 스팸 필터 파라미터
+    ("spam.url_ratio_threshold", "0.3", "0.3", "스팸: URL 비율 임계값"),
+    ("spam.keyword_threshold",   "3",   "3",   "스팸: 스팸키워드 개수 임계값"),
+    ("spam.min_content_length",  "20",  "20",  "스팸: 최소 본문 길이"),
+    ("spam.non_trend_min_hits",  "2",   "2",   "비트렌드: 키워드 최소 매칭 수"),
+    # 키워드 추출 파라미터
+    ("keyword.title_boost",    "2.0", "2.0", "키워드: 제목 토큰 가중치"),
+    ("keyword.body_max_chars", "500", "500", "키워드: 본문 최대 처리 글자 수"),
+    ("keyword.top_k",          "10",  "10",  "키워드: 추출 상위 K개"),
+]
+
+
+async def up(conn: asyncpg.Connection) -> None:
+    """Seed all config tables and admin_settings algorithm params."""
+    await seed_stopwords(conn)
+    await seed_filter_keywords(conn)
+    await seed_category_keywords(conn)
+
+    inserted = 0
+    for key, value, default_value, description in _ADMIN_SETTINGS:
+        result = await conn.fetchval(
+            """
+            INSERT INTO admin_settings (key, value, default_value, description)
+            VALUES ($1, to_jsonb($2::text), to_jsonb($3::text), $4)
+            ON CONFLICT (key) DO NOTHING
+            RETURNING key
+            """,
+            key,
+            value,
+            default_value,
+            description,
+        )
+        if result:
+            inserted += 1
+
+    logger.info(
+        "migration_025_complete",
+        admin_settings_inserted=inserted,
+        admin_settings_total=len(_ADMIN_SETTINGS),
+    )
+
+
+async def down(conn: asyncpg.Connection) -> None:
+    """Remove seeded config data."""
+    # admin_settings 파라미터 삭제
+    keys = [row[0] for row in _ADMIN_SETTINGS]
+    await conn.execute(
+        "DELETE FROM admin_settings WHERE key = ANY($1::text[])",
+        keys,
+    )
+    # 시드 데이터 삭제 (source='system'만)
+    await conn.execute("DELETE FROM stopword WHERE source = 'system'")
+    await conn.execute("DELETE FROM filter_keyword WHERE source = 'system'")
+    await conn.execute("DELETE FROM category_keyword WHERE source = 'system'")
+    logger.info("migration_025_reverted")

--- a/migrations/runner.py
+++ b/migrations/runner.py
@@ -34,6 +34,9 @@ MIGRATIONS: list[str] = [
     "migrations.020_growth_type",
     "migrations.021_keyword_snapshot",
     "migrations.022_naver_datalab_source",
+    "migrations.023_config_tables",
+    "migrations.024_burst_score",
+    "migrations.025_seed_config_data",
 ]
 
 

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,315 @@
+"""Tests for backend/processor/shared/config_loader.py."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from backend.processor.shared.config_loader import (
+    _cast,
+    get_category_keywords,
+    get_filter_keywords,
+    get_setting,
+    get_stopwords,
+    invalidate_cache,
+)
+
+
+def _make_pool(fetchrow_return=None, fetch_return=None) -> MagicMock:
+    """Build a minimal mock asyncpg pool."""
+    pool = MagicMock()
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value=fetchrow_return)
+    conn.fetch = AsyncMock(return_value=fetch_return or [])
+    pool.acquire = MagicMock(
+        return_value=MagicMock(
+            __aenter__=AsyncMock(return_value=conn),
+            __aexit__=AsyncMock(return_value=None),
+        )
+    )
+    return pool
+
+
+# ── _cast ────────────────────────────────────────────────────────────────────
+
+
+class TestCast:
+    def test_cast_to_float(self) -> None:
+        assert _cast("0.35", 0.0) == pytest.approx(0.35)
+
+    def test_cast_to_int(self) -> None:
+        assert _cast("3", 0) == 3
+
+    def test_cast_float_string_to_int(self) -> None:
+        assert _cast("2.0", 0) == 2
+
+    def test_cast_to_str(self) -> None:
+        assert _cast("gemini-flash", "") == "gemini-flash"
+
+    def test_cast_invalid_returns_default(self) -> None:
+        assert _cast("not_a_number", 1.0) == 1.0
+
+    def test_cast_invalid_int_returns_default(self) -> None:
+        assert _cast("abc", 5) == 5
+
+
+# ── get_setting ──────────────────────────────────────────────────────────────
+
+
+class TestGetSetting:
+    @pytest.mark.asyncio
+    async def test_cache_hit_returns_value(self) -> None:
+        pool = _make_pool()
+        with patch(
+            "backend.processor.shared.config_loader.get_cached",
+            AsyncMock(return_value=b"0.65"),
+        ):
+            result = await get_setting(pool, "cluster.threshold", 0.55)
+        assert result == pytest.approx(0.65)
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_loads_from_db(self) -> None:
+        pool = _make_pool(fetchrow_return={"value": '"0.70"'})
+        with (
+            patch(
+                "backend.processor.shared.config_loader.get_cached",
+                AsyncMock(return_value=None),
+            ),
+            patch(
+                "backend.processor.shared.config_loader.set_cached",
+                AsyncMock(),
+            ),
+        ):
+            result = await get_setting(pool, "cluster.louvain_threshold", 0.55)
+        assert result == pytest.approx(0.70)
+
+    @pytest.mark.asyncio
+    async def test_key_not_found_returns_default(self) -> None:
+        pool = _make_pool(fetchrow_return=None)
+        with (
+            patch(
+                "backend.processor.shared.config_loader.get_cached",
+                AsyncMock(return_value=None),
+            ),
+            patch(
+                "backend.processor.shared.config_loader.set_cached",
+                AsyncMock(),
+            ),
+        ):
+            result = await get_setting(pool, "nonexistent.key", 42)
+        assert result == 42
+
+    @pytest.mark.asyncio
+    async def test_db_error_returns_default(self) -> None:
+        pool = MagicMock()
+        pool.acquire = MagicMock(side_effect=RuntimeError("DB down"))
+        with patch(
+            "backend.processor.shared.config_loader.get_cached",
+            AsyncMock(return_value=None),
+        ):
+            result = await get_setting(pool, "cluster.threshold", 0.55)
+        assert result == pytest.approx(0.55)
+
+
+# ── get_stopwords ─────────────────────────────────────────────────────────────
+
+
+class TestGetStopwords:
+    @pytest.mark.asyncio
+    async def test_cache_hit(self) -> None:
+        pool = _make_pool()
+        cached_words = json.dumps(["것이", "하는", "있는"]).encode()
+        with patch(
+            "backend.processor.shared.config_loader.get_cached",
+            AsyncMock(return_value=cached_words),
+        ):
+            result = await get_stopwords(pool, "ko")
+        assert "것이" in result
+        assert "하는" in result
+        assert isinstance(result, frozenset)
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_loads_from_db(self) -> None:
+        rows = [{"word": "1월"}, {"word": "12월"}, {"word": "분기"}]
+        pool = _make_pool(fetch_return=rows)
+        with (
+            patch(
+                "backend.processor.shared.config_loader.get_cached",
+                AsyncMock(return_value=None),
+            ),
+            patch(
+                "backend.processor.shared.config_loader.set_cached",
+                AsyncMock(),
+            ),
+        ):
+            result = await get_stopwords(pool, "ko")
+        assert "1월" in result
+        assert "12월" in result
+
+    @pytest.mark.asyncio
+    async def test_locale_separation(self) -> None:
+        """ko와 en은 별도 캐시 키를 사용해야 한다."""
+        calls: list[str] = []
+
+        async def mock_get_cached(key: str) -> None:
+            calls.append(key)
+            return None
+
+        pool = _make_pool(fetch_return=[])
+        with (
+            patch(
+                "backend.processor.shared.config_loader.get_cached",
+                mock_get_cached,
+            ),
+            patch(
+                "backend.processor.shared.config_loader.set_cached",
+                AsyncMock(),
+            ),
+        ):
+            await get_stopwords(pool, "ko")
+            await get_stopwords(pool, "en")
+
+        ko_keys = [k for k in calls if "ko" in k]
+        en_keys = [k for k in calls if "en" in k]
+        assert len(ko_keys) >= 1
+        assert len(en_keys) >= 1
+        assert ko_keys[0] != en_keys[0]
+
+
+# ── get_filter_keywords ───────────────────────────────────────────────────────
+
+
+class TestGetFilterKeywords:
+    @pytest.mark.asyncio
+    async def test_category_filter(self) -> None:
+        rows = [{"keyword": "부고"}, {"keyword": "서거"}, {"keyword": "별세"}]
+        pool = _make_pool(fetch_return=rows)
+        with (
+            patch(
+                "backend.processor.shared.config_loader.get_cached",
+                AsyncMock(return_value=None),
+            ),
+            patch(
+                "backend.processor.shared.config_loader.set_cached",
+                AsyncMock(),
+            ),
+        ):
+            result = await get_filter_keywords(pool, category="obituary")
+        assert "부고" in result
+        assert "서거" in result
+        assert isinstance(result, frozenset)
+
+    @pytest.mark.asyncio
+    async def test_no_category_returns_all(self) -> None:
+        rows = [{"keyword": "부고"}, {"keyword": "광고"}, {"keyword": "카지노"}]
+        pool = _make_pool(fetch_return=rows)
+        with (
+            patch(
+                "backend.processor.shared.config_loader.get_cached",
+                AsyncMock(return_value=None),
+            ),
+            patch(
+                "backend.processor.shared.config_loader.set_cached",
+                AsyncMock(),
+            ),
+        ):
+            result = await get_filter_keywords(pool)
+        assert len(result) == 3
+
+    @pytest.mark.asyncio
+    async def test_db_error_returns_empty_frozenset(self) -> None:
+        pool = MagicMock()
+        pool.acquire = MagicMock(side_effect=RuntimeError("DB down"))
+        with patch(
+            "backend.processor.shared.config_loader.get_cached",
+            AsyncMock(return_value=None),
+        ):
+            result = await get_filter_keywords(pool, "obituary")
+        assert result == frozenset()
+
+
+# ── get_category_keywords ─────────────────────────────────────────────────────
+
+
+class TestGetCategoryKeywords:
+    @pytest.mark.asyncio
+    async def test_groups_by_category(self) -> None:
+        rows = [
+            {"keyword": "축구", "category": "sports", "weight": 1.5},
+            {"keyword": "야구", "category": "sports", "weight": 1.5},
+            {"keyword": "반도체", "category": "tech", "weight": 1.5},
+        ]
+        pool = _make_pool(fetch_return=rows)
+        with (
+            patch(
+                "backend.processor.shared.config_loader.get_cached",
+                AsyncMock(return_value=None),
+            ),
+            patch(
+                "backend.processor.shared.config_loader.set_cached",
+                AsyncMock(),
+            ),
+        ):
+            result = await get_category_keywords(pool)
+
+        assert "sports" in result
+        assert "tech" in result
+        assert ("축구", 1.5) in result["sports"]
+        assert ("반도체", 1.5) in result["tech"]
+
+
+# ── invalidate_cache ──────────────────────────────────────────────────────────
+
+
+class TestInvalidateCache:
+    @pytest.mark.asyncio
+    async def test_invalidate_specific_setting(self) -> None:
+        deleted: list[str] = []
+
+        async def mock_delete(key: str) -> None:
+            deleted.append(key)
+
+        with patch("backend.processor.shared.config_loader.delete_cached", mock_delete):
+            await invalidate_cache("setting:cluster.threshold")
+
+        assert any("cluster.threshold" in k for k in deleted)
+
+    @pytest.mark.asyncio
+    async def test_invalidate_stopwords_both_locales(self) -> None:
+        deleted: list[str] = []
+
+        async def mock_delete(key: str) -> None:
+            deleted.append(key)
+
+        with patch("backend.processor.shared.config_loader.delete_cached", mock_delete):
+            await invalidate_cache("stopwords")
+
+        ko_deleted = any("ko" in k for k in deleted)
+        en_deleted = any("en" in k for k in deleted)
+        assert ko_deleted
+        assert en_deleted
+
+    @pytest.mark.asyncio
+    async def test_invalidate_filter_kw(self) -> None:
+        deleted: list[str] = []
+
+        async def mock_delete(key: str) -> None:
+            deleted.append(key)
+
+        with patch("backend.processor.shared.config_loader.delete_cached", mock_delete):
+            await invalidate_cache("filter_kw")
+
+        assert len(deleted) > 0
+
+    @pytest.mark.asyncio
+    async def test_invalidate_category_kw(self) -> None:
+        deleted: list[str] = []
+
+        async def mock_delete(key: str) -> None:
+            deleted.append(key)
+
+        with patch("backend.processor.shared.config_loader.delete_cached", mock_delete):
+            await invalidate_cache("category_kw")
+
+        assert len(deleted) == 1


### PR DESCRIPTION
## Summary
- **migrations 023**: `stopword`, `filter_keyword`, `category_keyword` 3개 테이블 생성
- **migrations 024**: `news_group.burst_score` 컬럼 + 인덱스 추가
- **migrations 025**: 불용어(206) · 필터키워드(50) · 카테고리키워드(105) · admin_settings 알고리즘 파라미터(26) 시드
- **`backend/processor/shared/config_loader`**: Redis 캐시 기반 설정 로더 신규 구현 — `get_setting`, `get_stopwords`, `get_filter_keywords`, `get_category_keywords`, `invalidate_cache`
- **`backend/db/seeds/*`**: 각 테이블별 시드 모듈 신규 추가

## Test plan
- [x] `pytest tests/test_config_loader.py` — 21 tests passed
- [x] 전체 테스트 1104 passed (75.96% coverage ≥ 70%)
- [x] ruff lint + format passed
- [x] secret scan passed
- [x] DB 컨테이너 내 migration 적용 확인 (stopword 206행, filter_keyword 50행, category_keyword 105행, burst_score 컬럼 존재)