### PR TITLE
Feat: 외부 트렌드 교차 검증 스코어 부스트

### DIFF
--- a/backend/jobs/early_trend_update.py
+++ b/backend/jobs/early_trend_update.py
@@ -7,6 +7,8 @@ from datetime import datetime, timezone
 import asyncpg
 import structlog
 
+from backend.processor.algorithms.external_trends import verify_external_trends
+
 logger = structlog.get_logger(__name__)
 
 _ACTIVE_WINDOW_HOURS = 48
@@ -34,6 +36,8 @@ async def run_early_trend_update(pool: asyncpg.Pool) -> int:
                 """
                 SELECT ng.id,
                        ng.burst_score,
+                       ng.keywords,
+                       ng.locale,
                        COUNT(na.id)::int AS article_count,
                        COUNT(DISTINCT na.source)::int AS unique_sources,
                        MAX(na.publish_time) AS newest_publish_time,
@@ -94,6 +98,13 @@ async def run_early_trend_update(pool: asyncpg.Pool) -> int:
                         score = 0.0
                     elif article_count < 3:
                         score = min(score, 0.3)
+
+                    # External trend cross-validation boost
+                    if score > 0.0:
+                        keywords = row["keywords"] or []
+                        locale = row["locale"] or "ko"
+                        external_boost = await verify_external_trends(pool, keywords, locale=locale)
+                        score = round(min(1.0, score * external_boost), 4)
 
                     await conn.execute(
                         "UPDATE news_group SET early_trend_score = $1 WHERE id = $2",

--- a/backend/processor/algorithms/external_trends.py
+++ b/backend/processor/algorithms/external_trends.py
@@ -1,0 +1,68 @@
+"""External trend cross-validation — boost scores confirmed by Google Trends + Naver DataLab."""
+
+from __future__ import annotations
+
+import asyncpg
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+_EXTERNAL_PLATFORMS = ("google_trends", "naver_datalab")
+_SNAPSHOT_WINDOW_HOURS = 24
+
+# Multiplier by number of matching external platforms
+_BOOST_MAP: dict[int, float] = {
+    0: 1.0,
+    1: 1.1,
+    2: 1.3,
+}
+
+
+async def verify_external_trends(
+    db_pool: asyncpg.Pool,
+    keywords: list[str],
+    locale: str = "ko",
+) -> float:
+    """Return a score multiplier based on external trend signal matching.
+
+    Cross-references cluster keywords against sns_trend table for
+    google_trends and naver_datalab platforms (last 24 hours).
+
+    Returns:
+        Multiplier in [1.0, 1.3] based on number of matching platforms.
+    """
+    if not keywords:
+        return 1.0
+
+    try:
+        async with db_pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT COUNT(DISTINCT platform) AS platform_count
+                FROM sns_trend
+                WHERE keyword = ANY($1::text[])
+                  AND locale = $2
+                  AND platform = ANY($3::text[])
+                  AND snapshot_at > NOW() - INTERVAL '24 hours'
+                """,
+                keywords,
+                locale,
+                list(_EXTERNAL_PLATFORMS),
+            )
+
+        platform_count = row["platform_count"] if row else 0
+        boost = _BOOST_MAP.get(platform_count, 1.3)
+
+        if boost > 1.0:
+            logger.debug(
+                "external_trend_boost",
+                keywords_sample=keywords[:3],
+                locale=locale,
+                platform_count=platform_count,
+                boost=boost,
+            )
+
+        return boost
+    except Exception as exc:
+        logger.warning("external_trend_verify_failed", error=str(exc))
+        return 1.0

--- a/backend/processor/stages/score.py
+++ b/backend/processor/stages/score.py
@@ -16,6 +16,7 @@ from backend.processor.algorithms.burst import (
     detect_burst,
 )
 from backend.processor.algorithms.cross_platform import verify_cross_platform
+from backend.processor.algorithms.external_trends import verify_external_trends
 from backend.processor.shared.score_calculator import (
     ScoreInput,
     ScoreResult,
@@ -217,13 +218,22 @@ async def stage_score(
 
             early_score = compute_early_trend_score(articles)
             cross_platform_multiplier = verify_cross_platform(articles)
+            external_boost = await verify_external_trends(
+                db_pool,
+                unique_keywords,
+                locale=rep_article.get("locale", "ko"),
+            )
 
             scored.append(
                 {
                     "cluster": cluster,
                     "articles": articles,
-                    "score": min(100.0, result.normalized * cross_platform_multiplier),
+                    "score": min(
+                        100.0,
+                        result.normalized * cross_platform_multiplier * external_boost,
+                    ),
                     "cross_platform_multiplier": cross_platform_multiplier,
+                    "external_trend_boost": external_boost,
                     "early_trend_score": early_score,
                     "title": group_title,
                     "category": rep_article.get("category", "general"),

--- a/migrations/030_external_trends_index.py
+++ b/migrations/030_external_trends_index.py
@@ -1,0 +1,25 @@
+"""030_external_trends_index — sns_trend 교차 검증 쿼리 최적화 인덱스."""
+
+from __future__ import annotations
+
+import asyncpg
+
+VERSION = "030"
+DESCRIPTION = "Add index on sns_trend for keyword+platform cross-validation queries"
+
+NON_TRANSACTIONAL = True  # CREATE INDEX CONCURRENTLY requires this
+
+
+async def up(conn: asyncpg.Connection) -> None:
+    await conn.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sns_trend_keyword_platform
+        ON sns_trend (keyword, platform, snapshot_at DESC)
+        """
+    )
+
+
+async def down(conn: asyncpg.Connection) -> None:
+    await conn.execute(
+        "DROP INDEX CONCURRENTLY IF EXISTS idx_sns_trend_keyword_platform"
+    )

--- a/migrations/runner.py
+++ b/migrations/runner.py
@@ -41,6 +41,7 @@ MIGRATIONS: list[str] = [
     "migrations.027_quality_settings",
     "migrations.028_quality_v2",
     "migrations.029_google_trends_sns",
+    "migrations.030_external_trends_index",
 ]
 
 

--- a/tests/test_early_trend_update.py
+++ b/tests/test_early_trend_update.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from backend.jobs.early_trend_update import run_early_trend_update
@@ -43,6 +43,8 @@ def _make_group_row(
     data = {
         "id": uuid.uuid4(),
         "burst_score": burst_score,
+        "keywords": ["테스트", "키워드"],
+        "locale": "ko",
         "article_count": article_count,
         "unique_sources": unique_sources,
         "newest_publish_time": now - timedelta(hours=hours_ago),
@@ -53,15 +55,20 @@ def _make_group_row(
     return row
 
 
+@patch(
+    "backend.jobs.early_trend_update.verify_external_trends",
+    new_callable=AsyncMock,
+    return_value=1.0,
+)
 class TestRunEarlyTrendUpdate:
     @pytest.mark.asyncio
-    async def test_returns_zero_when_no_groups(self) -> None:
+    async def test_returns_zero_when_no_groups(self, _mock_ext: AsyncMock) -> None:
         pool = _make_pool(groups=[])
         result = await run_early_trend_update(pool)
         assert result == 0
 
     @pytest.mark.asyncio
-    async def test_updates_groups_and_returns_count(self) -> None:
+    async def test_updates_groups_and_returns_count(self, _mock_ext: AsyncMock) -> None:
         rows = [
             _make_group_row(
                 article_count=5,
@@ -76,7 +83,7 @@ class TestRunEarlyTrendUpdate:
         assert result == 1
 
     @pytest.mark.asyncio
-    async def test_momentum_velocity_high_acceleration(self) -> None:
+    async def test_momentum_velocity_high_acceleration(self, _mock_ext: AsyncMock) -> None:
         """High recent activity relative to 24h average → high velocity."""
         rows = [
             _make_group_row(
@@ -102,7 +109,7 @@ class TestRunEarlyTrendUpdate:
         assert 0.6 < score < 0.85
 
     @pytest.mark.asyncio
-    async def test_score_decreases_with_old_articles(self) -> None:
+    async def test_score_decreases_with_old_articles(self, _mock_ext: AsyncMock) -> None:
         """Articles from 40 hours ago should have low recency."""
         rows = [
             _make_group_row(
@@ -126,7 +133,7 @@ class TestRunEarlyTrendUpdate:
         assert score < 0.3
 
     @pytest.mark.asyncio
-    async def test_single_source_returns_zero(self) -> None:
+    async def test_single_source_returns_zero(self, _mock_ext: AsyncMock) -> None:
         """Single source cluster should get score 0."""
         rows = [
             _make_group_row(
@@ -148,7 +155,7 @@ class TestRunEarlyTrendUpdate:
         assert score == 0.0
 
     @pytest.mark.asyncio
-    async def test_small_cluster_capped(self) -> None:
+    async def test_small_cluster_capped(self, _mock_ext: AsyncMock) -> None:
         """Clusters with <3 articles should be capped at 0.3."""
         rows = [
             _make_group_row(
@@ -171,7 +178,7 @@ class TestRunEarlyTrendUpdate:
         assert score <= 0.3
 
     @pytest.mark.asyncio
-    async def test_handles_row_error_gracefully(self) -> None:
+    async def test_handles_row_error_gracefully(self, _mock_ext: AsyncMock) -> None:
         """A bad row should not stop processing of other rows."""
         good_row = _make_group_row(cnt_1h=2, cnt_24h=5)
         bad_row = MagicMock()
@@ -182,7 +189,7 @@ class TestRunEarlyTrendUpdate:
         assert result == 1
 
     @pytest.mark.asyncio
-    async def test_raises_on_db_connection_error(self) -> None:
+    async def test_raises_on_db_connection_error(self, _mock_ext: AsyncMock) -> None:
         pool = MagicMock()
         ctx = MagicMock()
         ctx.__aenter__ = AsyncMock(side_effect=RuntimeError("connection refused"))

--- a/tests/test_external_trends.py
+++ b/tests/test_external_trends.py
@@ -1,0 +1,96 @@
+"""Tests for backend.processor.algorithms.external_trends."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from backend.processor.algorithms.external_trends import verify_external_trends
+
+
+def _make_pool(platform_count: int = 0) -> MagicMock:
+    """Create a mock pool that returns a given platform_count."""
+    pool = MagicMock()
+    mock_conn = MagicMock()
+
+    row = {"platform_count": platform_count}
+    mock_conn.fetchrow = AsyncMock(return_value=row)
+
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=mock_conn)
+    ctx.__aexit__ = AsyncMock(return_value=None)
+    pool.acquire.return_value = ctx
+
+    return pool
+
+
+class TestVerifyExternalTrends:
+    @pytest.mark.asyncio
+    async def test_empty_keywords_returns_1(self) -> None:
+        pool = _make_pool()
+        result = await verify_external_trends(pool, [], locale="ko")
+        assert result == 1.0
+
+    @pytest.mark.asyncio
+    async def test_no_match_returns_1(self) -> None:
+        pool = _make_pool(platform_count=0)
+        result = await verify_external_trends(pool, ["AI", "인공지능"], locale="ko")
+        assert result == 1.0
+
+    @pytest.mark.asyncio
+    async def test_single_platform_match_returns_1_1(self) -> None:
+        pool = _make_pool(platform_count=1)
+        result = await verify_external_trends(pool, ["AI"], locale="ko")
+        assert result == 1.1
+
+    @pytest.mark.asyncio
+    async def test_dual_platform_match_returns_1_3(self) -> None:
+        pool = _make_pool(platform_count=2)
+        result = await verify_external_trends(pool, ["AI"], locale="ko")
+        assert result == 1.3
+
+    @pytest.mark.asyncio
+    async def test_more_than_2_platforms_capped_at_1_3(self) -> None:
+        pool = _make_pool(platform_count=5)
+        result = await verify_external_trends(pool, ["AI"], locale="ko")
+        assert result == 1.3
+
+    @pytest.mark.asyncio
+    async def test_db_error_returns_1(self) -> None:
+        pool = MagicMock()
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(side_effect=RuntimeError("connection lost"))
+        ctx.__aexit__ = AsyncMock(return_value=None)
+        pool.acquire.return_value = ctx
+
+        result = await verify_external_trends(pool, ["AI"], locale="ko")
+        assert result == 1.0
+
+    @pytest.mark.asyncio
+    async def test_null_row_returns_1(self) -> None:
+        pool = MagicMock()
+        mock_conn = MagicMock()
+        mock_conn.fetchrow = AsyncMock(return_value=None)
+
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=mock_conn)
+        ctx.__aexit__ = AsyncMock(return_value=None)
+        pool.acquire.return_value = ctx
+
+        result = await verify_external_trends(pool, ["AI"], locale="ko")
+        assert result == 1.0
+
+    @pytest.mark.asyncio
+    async def test_query_uses_correct_parameters(self) -> None:
+        pool = _make_pool(platform_count=1)
+        await verify_external_trends(pool, ["AI", "ChatGPT"], locale="en")
+
+        ctx = pool.acquire.return_value
+        conn = await ctx.__aenter__()
+        call_args = conn.fetchrow.call_args
+
+        # Verify keywords, locale, and platforms are passed
+        assert call_args[0][1] == ["AI", "ChatGPT"]
+        assert call_args[0][2] == "en"
+        assert "google_trends" in call_args[0][3]
+        assert "naver_datalab" in call_args[0][3]


### PR DESCRIPTION
## Summary
- `verify_external_trends()` 함수 추가: sns_trend 테이블에서 클러스터 키워드와 외부 트렌드(Google Trends, Naver DataLab) 교차 검증
- 매칭 플랫폼 수에 따른 스코어 부스트: 0개 → 1.0x, 1개 → 1.1x, 2개 → 1.3x
- `stage_score()` 파이프라인 및 `early_trend_update` 5분 주기 재계산 양쪽에 적용
- sns_trend (keyword, platform, snapshot_at) 복합 인덱스 마이그레이션 추가

## Changes
- `backend/processor/algorithms/external_trends.py` — 신규: 교차 검증 알고리즘
- `backend/processor/stages/score.py` — external boost 적용
- `backend/jobs/early_trend_update.py` — keywords/locale 조회 + external boost 적용
- `migrations/030_external_trends_index.py` — 쿼리 최적화 인덱스 (CONCURRENTLY)
- `migrations/runner.py` — 030 등록
- `tests/test_external_trends.py` — 단위 테스트 8건
- `tests/test_early_trend_update.py` — mock 업데이트 + verify_external_trends 패치

## Test plan
- [x] pytest 1154 passed, 75.94% coverage
- [x] ruff lint/format 통과
- [x] test_external_trends: 8개 케이스 (매칭 0/1/2, 빈 키워드, DB 에러, null row 등)
- [x] test_early_trend_update: verify_external_trends 패치 + keywords/locale 필드 검증

Ref: #223