### PR TITLE
Fix: 트렌드 품질 개선 — 관련 트렌드 필터 + 클러스터 노이즈 품질 강화

### DIFF
--- a/backend/db/queries/trends.py
+++ b/backend/db/queries/trends.py
@@ -277,6 +277,8 @@ async def fetch_related_trends(
                     WHERE id = $1::uuid
                 )
                   AND ng.id <> $1::uuid
+                  AND ng.is_hidden = FALSE
+                  AND (SELECT COUNT(*) FROM news_article WHERE group_id = ng.id) >= 2
                 ORDER BY ng.score DESC
                 LIMIT $2
                 """,  # noqa: S608

--- a/backend/processor/shared/semantic_clusterer.py
+++ b/backend/processor/shared/semantic_clusterer.py
@@ -344,9 +344,9 @@ def _cluster_hdbscan(
 
         # Noise points (label == -1) become singletons only if quality threshold met
         for noise_item in label_groups.get(-1, []):
-            title = noise_item.get("title", "")
-            keywords = noise_item.get("keywords", [])
-            if len(title) >= 15 and len(keywords) >= 2:
+            text = noise_item.text if isinstance(noise_item, ClusterItem) else ""
+            kws = noise_item.keywords if isinstance(noise_item, ClusterItem) else set()
+            if len(text) >= 20 and len(kws) >= 3:
                 clusters.append(
                     Cluster(
                         cluster_id=f"noise_{cluster_idx}",

--- a/tests/test_early_trend_update.py
+++ b/tests/test_early_trend_update.py
@@ -174,9 +174,7 @@ class TestRunEarlyTrendUpdate:
         assert score == 0.0
 
     @pytest.mark.asyncio
-    async def test_small_cluster_capped(
-        self, _mock_score: AsyncMock, _mock_ext: AsyncMock
-    ) -> None:
+    async def test_small_cluster_capped(self, _mock_score: AsyncMock, _mock_ext: AsyncMock) -> None:
         """Clusters with <3 articles should be capped at 0.3."""
         _mock_score.return_value = 0.8
         rows = [

--- a/tests/test_semantic_clusterer.py
+++ b/tests/test_semantic_clusterer.py
@@ -288,24 +288,24 @@ class TestHdbscanClustering:
         items = [
             ClusterItem(
                 item_id="1",
-                text="a",
-                keywords={"경제"},
+                text="경제 성장률이 올해 들어 크게 개선됨",
+                keywords={"경제", "성장률", "개선"},
                 published_at=now,
                 source_type="news",
                 embedding=[1.0, 0.0, 0.0],
             ),
             ClusterItem(
                 item_id="2",
-                text="b",
-                keywords={"스포츠"},
+                text="프로야구 시즌 개막 관중 기록 경신 소식",
+                keywords={"스포츠", "프로야구", "관중"},
                 published_at=past,
                 source_type="blog",
                 embedding=[0.0, 1.0, 0.0],
             ),
             ClusterItem(
                 item_id="3",
-                text="c",
-                keywords={"정치"},
+                text="국회 본회의에서 예산안 통과 논란 확산",
+                keywords={"정치", "국회", "예산안"},
                 published_at=past,
                 source_type="sns",
                 embedding=[0.0, 0.0, 1.0],
@@ -316,13 +316,13 @@ class TestHdbscanClustering:
         assert len(clusters) >= 2
 
     def test_hdbscan_all_items_preserved(self) -> None:
-        """No items should be lost during clustering."""
+        """Quality noise items should be preserved during clustering."""
         now = datetime.now(timezone.utc)
         items = [
             ClusterItem(
                 item_id=f"item_{i}",
-                text=f"text {i}",
-                keywords={f"kw{i}"},
+                text=f"이것은 충분히 긴 테스트 텍스트 아이템 번호 {i}",
+                keywords={f"키워드{i}", f"주제{i}", f"태그{i}"},
                 published_at=now,
                 embedding=[float(i), 0.0, 0.0],
             )


### PR DESCRIPTION
## Summary
- `fetch_related_trends()` 쿼리에 `is_hidden = FALSE` + 기사 2건 이상 필터 추가
- 클러스터 노이즈 포인트 품질 기준 강화: 텍스트 20자 이상, 키워드 3개 이상
- ClusterItem dataclass 속성 접근 버그 수정 (dict.get → attribute access)

## Test plan
- [x] 전체 1159 테스트 통과 (76.01% coverage)
- [x] `test_hdbscan_separates_dissimilar` — 강화된 품질 기준으로 통과
- [x] `test_hdbscan_all_items_preserved` — 강화된 품질 기준으로 통과
- [x] ruff lint + format 통과

Closes: #221