### PR TITLE
Fix: Migration 029 source_type NOT NULL 오류 수정

### DIFF
--- a/migrations/029_google_trends_sns.py
+++ b/migrations/029_google_trends_sns.py
@@ -12,8 +12,8 @@ async def up(conn: asyncpg.Connection) -> None:
     # 1) source_config for Google Trends RSS quota
     await conn.execute(
         """
-        INSERT INTO source_config (source_name, is_active, quota_limit, quota_used)
-        VALUES ('google_trends_rss', TRUE, 100, 0)
+        INSERT INTO source_config (source_name, source_type, is_active, quota_limit, quota_used)
+        VALUES ('google_trends_rss', 'rss', TRUE, 100, 0)
         ON CONFLICT (source_name) DO NOTHING
         """
     )


### PR DESCRIPTION
## Summary
- `source_config` INSERT 시 `source_type` 컬럼 누락 → NOT NULL 위반으로 API 컨테이너 재시작 루프
- `source_type = 'rss'` 추가하여 해결

## Test plan
- [x] 전체 1159 테스트 통과 (76% coverage)
- [x] ruff lint + format 통과

Closes: #229