### PR TITLE
Fix: Migration 030 CONCURRENTLY 트랜잭션 오류 수정

### DIFF
--- a/migrations/030_external_trends_index.py
+++ b/migrations/030_external_trends_index.py
@@ -7,7 +7,7 @@ import asyncpg
 VERSION = "030"
 DESCRIPTION = "Add index on sns_trend for keyword+platform cross-validation queries"
 
-NON_TRANSACTIONAL = True  # CREATE INDEX CONCURRENTLY requires this
+TRANSACTIONAL = False  # CREATE INDEX CONCURRENTLY cannot run inside a transaction
 
 
 async def up(conn: asyncpg.Connection) -> None:


### PR DESCRIPTION
## Summary
- `NON_TRANSACTIONAL = True` → `TRANSACTIONAL = False`로 변경
- runner.py가 `TRANSACTIONAL` 속성을 체크하는데 030은 `NON_TRANSACTIONAL`로 잘못 설정됨
- CREATE INDEX CONCURRENTLY가 트랜잭션 블록에서 실행되어 에러 발생

## Test plan
- [x] 1159 테스트 통과 (76% coverage)

Closes: #232