### PR TITLE
Fix: Tracker 알림 토글 서버 영속화 (Wave 2)

### DIFF
--- a/backend/api/routers/notifications.py
+++ b/backend/api/routers/notifications.py
@@ -6,6 +6,7 @@ import structlog
 from fastapi import APIRouter, Depends, Request
 
 from backend.api.schemas.notifications import (
+    KeywordAlertUpdate,
     KeywordCreateRequest,
     KeywordResponse,
     KeywordsResponse,
@@ -21,6 +22,7 @@ from backend.db.queries.notification_keywords import (
     delete_keyword,
     get_keywords_for_user,
     insert_keyword,
+    update_keyword_alerts,
 )
 from backend.db.queries.notifications import (
     get_notification_settings,
@@ -118,6 +120,8 @@ async def list_keywords(
                 id=row["id"],
                 user_id=row["user_id"],
                 keyword=row["keyword"],
+                alert_surge=row["alert_surge"],
+                alert_daily=row["alert_daily"],
                 created_at=row["created_at"],
             )
             for row in rows
@@ -157,6 +161,44 @@ async def add_keyword(
         id=row["id"],
         user_id=row["user_id"],
         keyword=row["keyword"],
+        alert_surge=row["alert_surge"],
+        alert_daily=row["alert_daily"],
+        created_at=row["created_at"],
+    )
+
+
+@router.patch("/keywords/{keyword_id}", response_model=KeywordResponse)
+@handle_errors(log_event="update_keyword_alerts_failed")
+async def patch_keyword_alerts(
+    keyword_id: str,
+    body: KeywordAlertUpdate,
+    request: Request,
+    current_user: CurrentUser = Depends(require_auth),  # noqa: B008
+) -> KeywordResponse:
+    """Update per-keyword alert toggles (surge / daily). Owner only."""
+    pool = request.app.state.db_pool
+    row = await update_keyword_alerts(
+        pool,
+        user_id=current_user.user_id,
+        keyword_id=keyword_id,
+        alert_surge=body.alert_surge,
+        alert_daily=body.alert_daily,
+    )
+    if row is None:
+        raise http_error(ErrorCode.NOT_FOUND, "Keyword not found", status_code=404)
+    logger.info(
+        "keyword_alerts_updated",
+        user_id=current_user.user_id,
+        keyword_id=keyword_id,
+        alert_surge=body.alert_surge,
+        alert_daily=body.alert_daily,
+    )
+    return KeywordResponse(
+        id=row["id"],
+        user_id=row["user_id"],
+        keyword=row["keyword"],
+        alert_surge=row["alert_surge"],
+        alert_daily=row["alert_daily"],
         created_at=row["created_at"],
     )
 

--- a/backend/api/schemas/notifications.py
+++ b/backend/api/schemas/notifications.py
@@ -31,10 +31,17 @@ class KeywordCreateRequest(BaseModel):
     keyword: str
 
 
+class KeywordAlertUpdate(BaseModel):
+    alert_surge: bool
+    alert_daily: bool
+
+
 class KeywordResponse(BaseModel):
     id: str
     user_id: str
     keyword: str
+    alert_surge: bool
+    alert_daily: bool
     created_at: datetime
 
 

--- a/backend/db/queries/notification_keywords.py
+++ b/backend/db/queries/notification_keywords.py
@@ -18,7 +18,8 @@ async def get_keywords_for_user(
         async with pool.acquire() as conn:
             return await conn.fetch(
                 """
-                SELECT id::text, user_id::text, keyword, created_at
+                SELECT id::text, user_id::text, keyword,
+                       alert_surge, alert_daily, created_at
                 FROM notification_keyword
                 WHERE user_id = $1::uuid
                 ORDER BY created_at ASC
@@ -60,7 +61,8 @@ async def insert_keyword(
                 """
                 INSERT INTO notification_keyword (user_id, keyword)
                 VALUES ($1::uuid, $2)
-                RETURNING id::text, user_id::text, keyword, created_at
+                RETURNING id::text, user_id::text, keyword,
+                          alert_surge, alert_daily, created_at
                 """,
                 user_id,
                 keyword,
@@ -68,6 +70,41 @@ async def insert_keyword(
         return row
     except Exception as exc:
         logger.error("insert_keyword_failed", user_id=user_id, keyword=keyword, error=str(exc))
+        raise
+
+
+async def update_keyword_alerts(
+    pool: asyncpg.Pool,
+    *,
+    user_id: str,
+    keyword_id: str,
+    alert_surge: bool,
+    alert_daily: bool,
+) -> asyncpg.Record | None:
+    """Update alert flags for a keyword. Returns the updated row or None if not found."""
+    try:
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                """
+                UPDATE notification_keyword
+                SET alert_surge = $3, alert_daily = $4
+                WHERE id = $1::uuid AND user_id = $2::uuid
+                RETURNING id::text, user_id::text, keyword,
+                          alert_surge, alert_daily, created_at
+                """,
+                keyword_id,
+                user_id,
+                alert_surge,
+                alert_daily,
+            )
+        return row
+    except Exception as exc:
+        logger.error(
+            "update_keyword_alerts_failed",
+            user_id=user_id,
+            keyword_id=keyword_id,
+            error=str(exc),
+        )
         raise
 
 

--- a/frontend/src/routes/tracker/+page.svelte
+++ b/frontend/src/routes/tracker/+page.svelte
@@ -13,9 +13,19 @@
 	import { Bell, BellOff, Trash2 } from 'lucide-svelte';
 
 	interface KeywordItem {
+		id: string;
 		keyword: string;
 		alertSurge: boolean;
 		alertDaily: boolean;
+	}
+
+	interface KeywordResponse {
+		id: string;
+		user_id: string;
+		keyword: string;
+		alert_surge: boolean;
+		alert_daily: boolean;
+		created_at: string;
 	}
 
 	type TrendStatus = 'exploding' | 'rising' | 'stable' | 'declining' | null;
@@ -52,8 +62,13 @@
 
 	async function loadKeywords(): Promise<void> {
 		try {
-			const data = await apiRequest<{ keywords: string[] }>('/notifications/keywords');
-			keywords = (data.keywords ?? []).map((kw) => ({ keyword: kw, alertSurge: true, alertDaily: false }));
+			const data = await apiRequest<{ keywords: KeywordResponse[] }>('/notifications/keywords');
+			keywords = (data.keywords ?? []).map((kw) => ({
+				id: kw.id,
+				keyword: kw.keyword,
+				alertSurge: kw.alert_surge,
+				alertDaily: kw.alert_daily,
+			}));
 			// fetch statuses concurrently (best-effort)
 			await Promise.allSettled(keywords.map((k) => fetchKeywordStatus(k.keyword)));
 		} catch {
@@ -77,11 +92,19 @@
 		}
 
 		try {
-			await apiRequest('/notifications/keywords', {
+			const created = await apiRequest<KeywordResponse>('/notifications/keywords', {
 				method: 'POST',
 				body: { keyword: trimmed },
 			});
-			keywords = [...keywords, { keyword: trimmed, alertSurge: true, alertDaily: false }];
+			keywords = [
+				...keywords,
+				{
+					id: created.id,
+					keyword: created.keyword,
+					alertSurge: created.alert_surge,
+					alertDaily: created.alert_daily,
+				},
+			];
 			newKeyword = '';
 			trackEvent('keyword_add', { keyword: trimmed });
 			fetchKeywordStatus(trimmed);
@@ -103,16 +126,16 @@
 		}
 	}
 
-	async function removeKeyword(keyword: string): Promise<void> {
+	async function removeKeyword(item: KeywordItem): Promise<void> {
 		try {
-			await apiRequest(`/notifications/keywords/${encodeURIComponent(keyword)}`, {
+			await apiRequest(`/notifications/keywords/${item.id}`, {
 				method: 'DELETE',
 			});
-			keywords = keywords.filter((k) => k.keyword !== keyword);
+			keywords = keywords.filter((k) => k.id !== item.id);
 			const next = new Map(keywordStatuses);
-			next.delete(keyword);
+			next.delete(item.keyword);
 			keywordStatuses = next;
-			trackEvent('keyword_remove', { keyword });
+			trackEvent('keyword_remove', { keyword: item.keyword });
 		} catch (error) {
 			if (error instanceof ApiRequestError) {
 				errorCode = error.errorCode;
@@ -122,15 +145,37 @@
 		}
 	}
 
-	function toggleAlert(keyword: string, type: 'surge' | 'daily'): void {
-		keywords = keywords.map((k) => {
-			if (k.keyword !== keyword) return k;
-			return {
-				...k,
-				alertSurge: type === 'surge' ? !k.alertSurge : k.alertSurge,
-				alertDaily: type === 'daily' ? !k.alertDaily : k.alertDaily,
-			};
-		});
+	async function toggleAlert(item: KeywordItem, type: 'surge' | 'daily'): Promise<void> {
+		const nextSurge = type === 'surge' ? !item.alertSurge : item.alertSurge;
+		const nextDaily = type === 'daily' ? !item.alertDaily : item.alertDaily;
+		try {
+			const updated = await apiRequest<KeywordResponse>(
+				`/notifications/keywords/${item.id}`,
+				{
+					method: 'PATCH',
+					body: { alert_surge: nextSurge, alert_daily: nextDaily },
+				}
+			);
+			keywords = keywords.map((k) =>
+				k.id === item.id
+					? {
+							...k,
+							alertSurge: updated.alert_surge,
+							alertDaily: updated.alert_daily,
+						}
+					: k
+			);
+		} catch (error) {
+			if (error instanceof ApiRequestError) {
+				errorCode = error.errorCode;
+				errorMessageKey = 'error.server';
+				errorOpen = true;
+			} else {
+				errorCode = 'ERR_NETWORK';
+				errorMessageKey = 'error.network';
+				errorOpen = true;
+			}
+		}
 	}
 
 	function getStatusBadge(status: TrendStatus): { icon: string; label: string; cls: string } | null {
@@ -210,7 +255,7 @@
 								</div>
 								<button
 									type="button"
-									onclick={() => removeKeyword(item.keyword)}
+									onclick={() => removeKeyword(item)}
 									class="flex-shrink-0 text-gray-400 hover:text-red-500 transition-colors"
 									aria-label="remove"
 								>
@@ -222,7 +267,7 @@
 							<div class="space-y-2">
 								<button
 									type="button"
-									onclick={() => toggleAlert(item.keyword, 'surge')}
+									onclick={() => toggleAlert(item, 'surge')}
 									class="w-full flex items-center justify-between rounded-md px-3 py-2 text-xs transition-colors {item.alertSurge ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-400' : 'bg-gray-50 dark:bg-gray-700 text-gray-500 dark:text-gray-400'}"
 								>
 									<span class="flex items-center gap-1.5">
@@ -238,7 +283,7 @@
 
 								<button
 									type="button"
-									onclick={() => toggleAlert(item.keyword, 'daily')}
+									onclick={() => toggleAlert(item, 'daily')}
 									class="w-full flex items-center justify-between rounded-md px-3 py-2 text-xs transition-colors {item.alertDaily ? 'bg-purple-50 dark:bg-purple-900/20 text-purple-700 dark:text-purple-400' : 'bg-gray-50 dark:bg-gray-700 text-gray-500 dark:text-gray-400'}"
 								>
 									<span class="flex items-center gap-1.5">

--- a/migrations/032_notification_keyword_alert_flags.py
+++ b/migrations/032_notification_keyword_alert_flags.py
@@ -1,0 +1,28 @@
+"""032: Add alert_surge / alert_daily flags to notification_keyword."""
+
+from __future__ import annotations
+
+import asyncpg
+
+VERSION = "032_notification_keyword_alert_flags"
+DESCRIPTION = "Persist per-keyword alert toggles (surge / daily) on notification_keyword"
+
+
+async def up(conn: asyncpg.Connection) -> None:
+    await conn.execute(
+        """
+        ALTER TABLE notification_keyword
+        ADD COLUMN IF NOT EXISTS alert_surge BOOLEAN NOT NULL DEFAULT TRUE,
+        ADD COLUMN IF NOT EXISTS alert_daily BOOLEAN NOT NULL DEFAULT FALSE
+        """
+    )
+
+
+async def down(conn: asyncpg.Connection) -> None:
+    await conn.execute(
+        """
+        ALTER TABLE notification_keyword
+        DROP COLUMN IF EXISTS alert_surge,
+        DROP COLUMN IF EXISTS alert_daily
+        """
+    )

--- a/tests/test_notification_keywords_api.py
+++ b/tests/test_notification_keywords_api.py
@@ -28,12 +28,16 @@ def _make_keyword_row(
     keyword: str = "AI",
     kw_id: str = "00000000-0000-0000-0000-000000000010",
     user_id: str = "00000000-0000-0000-0000-000000000001",
+    alert_surge: bool = True,
+    alert_daily: bool = False,
 ) -> MagicMock:
     row = MagicMock()
     row.__getitem__ = lambda self, key: {
         "id": kw_id,
         "user_id": user_id,
         "keyword": keyword,
+        "alert_surge": alert_surge,
+        "alert_daily": alert_daily,
         "created_at": datetime(2026, 3, 19, 0, 0, 0, tzinfo=timezone.utc),
     }[key]
     return row
@@ -231,3 +235,50 @@ class TestDeleteKeyword:
         )
         assert resp.status_code == 500
         assert resp.json()["code"] == "E0040"
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/v1/notifications/keywords/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestPatchKeywordAlerts:
+    async def test_updates_alert_flags(
+        self, kw_client: AsyncClient, mock_db_pool: MagicMock
+    ) -> None:
+        token = _make_token("pro")
+        conn = mock_db_pool.acquire.return_value.__aenter__.return_value
+        conn.fetchrow = AsyncMock(
+            return_value=_make_keyword_row(alert_surge=False, alert_daily=True)
+        )
+
+        resp = await kw_client.patch(
+            "/api/v1/notifications/keywords/00000000-0000-0000-0000-000000000010",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"alert_surge": False, "alert_daily": True},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["alert_surge"] is False
+        assert body["alert_daily"] is True
+
+    async def test_patch_not_found_returns_404(
+        self, kw_client: AsyncClient, mock_db_pool: MagicMock
+    ) -> None:
+        token = _make_token("pro")
+        mock_db_pool.acquire.return_value.__aenter__.return_value.fetchrow = AsyncMock(
+            return_value=None
+        )
+        resp = await kw_client.patch(
+            "/api/v1/notifications/keywords/00000000-0000-0000-0000-000000000099",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"alert_surge": True, "alert_daily": False},
+        )
+        assert resp.status_code == 404
+
+    async def test_unauthenticated_gets_401(self, kw_client: AsyncClient) -> None:
+        resp = await kw_client.patch(
+            "/api/v1/notifications/keywords/00000000-0000-0000-0000-000000000010",
+            json={"alert_surge": True, "alert_daily": True},
+        )
+        assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- notification_keyword 테이블에 alert_surge/alert_daily 컬럼 추가 (migration 032)
- PATCH /api/v1/notifications/keywords/{id} 엔드포인트 신설 + 쿼리 계층 확장
- Tracker 페이지: 로컬 state-only 토글 → 서버 PATCH 연동, DELETE는 id 기반
- F4 (Tracker 토글 미저장) 해결

## Test plan
- [x] pytest tests/test_notification_keywords_api.py (17 passed)
- [x] 전체 pytest + coverage 76.56%
- [x] ruff lint/format
- [x] svelte-check (tracker 관련 신규 오류 없음)

Closes #237
Ref: docs/audit-2026-04-14-plan.md Wave 2