### PR TITLE
Fix: SNS/naver_datalab/burst crawler에 Prometheus 메트릭 연결 (Wave 3)

### DIFF
--- a/backend/crawler/sources/burst_crawler.py
+++ b/backend/crawler/sources/burst_crawler.py
@@ -12,6 +12,7 @@ import feedparser
 import httpx
 import structlog
 
+from backend.common.metrics import CRAWLER_REQUESTS
 from backend.processor.shared.dedupe_filter import (
     compute_content_fingerprint as _content_fp,
 )
@@ -252,6 +253,7 @@ async def run_burst_crawl(
                 error=str(reddit_result),
             )
 
+        CRAWLER_REQUESTS.labels(source="burst", result="success").inc()
         logger.info(
             "burst_crawl_complete",
             keywords=keywords,
@@ -260,6 +262,7 @@ async def run_burst_crawl(
         )
         return total
     except Exception as exc:
+        CRAWLER_REQUESTS.labels(source="burst", result="failure").inc()
         logger.error("burst_crawl_failed", keywords=keywords, error=str(exc))
         return 0
 

--- a/backend/crawler/sources/naver_datalab_crawler.py
+++ b/backend/crawler/sources/naver_datalab_crawler.py
@@ -11,6 +11,7 @@ import asyncpg
 import httpx
 import structlog
 
+from backend.common.metrics import CRAWLER_REQUESTS
 from backend.crawler.quota_guard import check_quota, increment_quota
 
 logger = structlog.get_logger(__name__)
@@ -67,7 +68,9 @@ async def fetch_naver_trends(
                 resp.raise_for_status()
                 data = resp.json()
                 results.extend(data.get("results", []))
+                CRAWLER_REQUESTS.labels(source="naver_datalab", result="success").inc()
             except Exception as exc:
+                CRAWLER_REQUESTS.labels(source="naver_datalab", result="failure").inc()
                 logger.warning("naver_datalab_fetch_failed", batch_index=i, error=str(exc))
 
     return results

--- a/backend/crawler/sources/sns_crawler.py
+++ b/backend/crawler/sources/sns_crawler.py
@@ -12,6 +12,7 @@ import feedparser
 import httpx
 import structlog
 
+from backend.common.metrics import CRAWLER_REQUESTS
 from backend.common.quota_alert import handle_api_exception
 from backend.crawler.quota_guard import check_quota, increment_quota
 from backend.crawler.sources.naver_datalab_crawler import crawl_naver_datalab
@@ -98,12 +99,14 @@ async def crawl_reddit(
                     await update_feed_health(
                         db_pool, row["id"], success=True, latency_ms=elapsed_ms
                     )
+                    CRAWLER_REQUESTS.labels(source="reddit", result="success").inc()
                     results.extend(posts)
                 except Exception as exc:
                     elapsed_ms = (time.monotonic() - t0) * 1000
                     await update_feed_health(
                         db_pool, row["id"], success=False, latency_ms=elapsed_ms, error=str(exc)
                     )
+                    CRAWLER_REQUESTS.labels(source="reddit", result="failure").inc()
                     await handle_api_exception(exc, "reddit", db_pool)
                     logger.warning("reddit_sub_error", subreddit=sub, error=str(exc))
                     continue
@@ -242,6 +245,7 @@ async def crawl_google_trends_rss(db_pool: asyncpg.Pool) -> list[dict[str, Any]]
                             latency_ms=elapsed_ms,
                             error=f"HTTP {resp.status_code}",
                         )
+                        CRAWLER_REQUESTS.labels(source="google_trends", result="failure").inc()
                         continue
 
                     parsed = feedparser.parse(resp.text)
@@ -287,6 +291,7 @@ async def crawl_google_trends_rss(db_pool: asyncpg.Pool) -> list[dict[str, Any]]
                     await update_feed_health(
                         db_pool, row["id"], success=True, latency_ms=elapsed_ms
                     )
+                    CRAWLER_REQUESTS.labels(source="google_trends", result="success").inc()
                 except Exception as exc:
                     elapsed_ms = (time.monotonic() - t0) * 1000
                     await update_feed_health(
@@ -296,6 +301,7 @@ async def crawl_google_trends_rss(db_pool: asyncpg.Pool) -> list[dict[str, Any]]
                         latency_ms=elapsed_ms,
                         error=str(exc),
                     )
+                    CRAWLER_REQUESTS.labels(source="google_trends", result="failure").inc()
                     await handle_api_exception(exc, "google_trends_rss", db_pool)
                     logger.warning(
                         "google_trends_rss_feed_error",
@@ -332,8 +338,10 @@ async def crawl_youtube(db_pool: asyncpg.Pool) -> list[dict[str, Any]]:
             for region, locale in [("KR", "ko"), ("US", "en")]:
                 try:
                     videos = await _fetch_youtube_trending(client, api_key, region, locale, db_pool)
+                    CRAWLER_REQUESTS.labels(source="youtube", result="success").inc()
                     results.extend(videos)
                 except Exception as exc:
+                    CRAWLER_REQUESTS.labels(source="youtube", result="failure").inc()
                     await handle_api_exception(exc, "youtube", db_pool)
                     logger.warning("youtube_region_error", region=region, error=str(exc))
                     continue

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -67,6 +67,108 @@ class TestCrawlerMetrics:
         assert after == before + 1
 
 
+class TestCrawlerSourceEmission:
+    """Wave 3: SNS / naver_datalab / burst crawler 경로가 실제로 CRAWLER_REQUESTS를 발행."""
+
+    @pytest.mark.asyncio
+    async def test_burst_crawl_success_increments(self) -> None:
+        from backend.crawler.sources import burst_crawler
+
+        before = CRAWLER_REQUESTS.labels(source="burst", result="success")._value.get()
+        with (
+            patch.object(burst_crawler, "search_google_news_rss", AsyncMock(return_value=[])),
+            patch.object(burst_crawler, "search_reddit", AsyncMock(return_value=[])),
+        ):
+            await burst_crawler.run_burst_crawl(["ai"], "ko", AsyncMock())
+        after = CRAWLER_REQUESTS.labels(source="burst", result="success")._value.get()
+        assert after == before + 1
+
+    @pytest.mark.asyncio
+    async def test_burst_crawl_failure_increments(self) -> None:
+        from backend.crawler.sources import burst_crawler
+
+        before = CRAWLER_REQUESTS.labels(source="burst", result="failure")._value.get()
+        with patch.object(
+            burst_crawler, "search_google_news_rss", AsyncMock(side_effect=RuntimeError("boom"))
+        ):
+            # asyncio.gather(return_exceptions=True) swallows the exception internally,
+            # so trigger outer except via an unexpected error path: pass a bad arg.
+            # Instead, test the except branch directly by forcing asyncio.gather to raise.
+            with patch.object(
+                burst_crawler.asyncio, "gather", AsyncMock(side_effect=RuntimeError("gather fail"))
+            ):
+                await burst_crawler.run_burst_crawl(["ai"], "ko", AsyncMock())
+        after = CRAWLER_REQUESTS.labels(source="burst", result="failure")._value.get()
+        assert after == before + 1
+
+    @pytest.mark.asyncio
+    async def test_naver_datalab_failure_increments(self) -> None:
+        from backend.crawler.sources import naver_datalab_crawler
+
+        before = CRAWLER_REQUESTS.labels(source="naver_datalab", result="failure")._value.get()
+        with patch.dict(
+            "os.environ",
+            {"NAVER_CLIENT_ID": "x", "NAVER_CLIENT_SECRET": "y"},
+        ):
+
+            class _FailingClient:
+                async def __aenter__(self) -> _FailingClient:
+                    return self
+
+                async def __aexit__(self, *args: object) -> None:
+                    return None
+
+                async def post(self, *args: object, **kwargs: object) -> None:
+                    raise RuntimeError("network")
+
+            with patch.object(
+                naver_datalab_crawler.httpx, "AsyncClient", lambda *a, **kw: _FailingClient()
+            ):
+                await naver_datalab_crawler.fetch_naver_trends(
+                    [{"groupName": "g", "keywords": ["k"]}]
+                )
+        after = CRAWLER_REQUESTS.labels(source="naver_datalab", result="failure")._value.get()
+        assert after == before + 1
+
+    def test_sns_source_labels_registered(self) -> None:
+        """reddit/youtube/google_trends label 쌍이 Counter에 유효하게 등록됨."""
+        for source in ("reddit", "youtube", "google_trends"):
+            for result in ("success", "failure"):
+                CRAWLER_REQUESTS.labels(source=source, result=result).inc(0)
+
+
+class TestMetricsEndpointExposure:
+    """GET /metrics 응답에 알림 룰이 참조하는 메트릭 이름이 모두 노출되는지 검증."""
+
+    @pytest.mark.asyncio
+    async def test_expected_metric_names_exposed(self) -> None:
+        from backend.api.main import create_app
+        from httpx import ASGITransport, AsyncClient
+
+        # 최소 1회 증가시켜 Counter가 /metrics 출력에 포함되도록 보장
+        CRAWLER_REQUESTS.labels(source="reddit", result="success").inc(0)
+        AI_API_REQUESTS.labels(provider="gemini", result="success").inc(0)
+        CACHE_REQUESTS.labels(result="hit").inc(0)
+        PAYMENT_FAILURES.inc(0)
+        SOURCE_QUOTA_RATIO.labels(source="test").set(0.0)
+
+        app = create_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/metrics")
+        assert resp.status_code == 200
+        body = resp.text
+        for name in (
+            "http_requests_total",
+            "cache_requests_total",
+            "crawler_requests_total",
+            "ai_api_requests_total",
+            "payment_failures_total",
+            "source_quota_ratio",
+        ):
+            assert name in body, f"{name} not found in /metrics output"
+
+
 class TestAIAPIMetrics:
     """AI API request metric tests."""
 


### PR DESCRIPTION
## Summary
- F5 재감사: 원안의 "4개 메트릭 전부 미발행" 중 SNS·naver_datalab·burst crawler `CRAWLER_REQUESTS`만 실질 누락 확인
- reddit/google_trends/youtube/naver_datalab/burst 경로 success/failure .inc() 연결
- 알림 룰(`HighCrawlerFailureRate`) 무변경
- `/metrics` 엔드포인트에 6개 핵심 메트릭 이름 노출 테스트 추가

## Test plan
- [x] pytest tests/test_metrics.py -x (15 passed)
- [x] 전체 pytest + coverage 76.57%
- [x] ruff check 통과

Closes #239
Ref: docs/audit-2026-04-14-plan.md Wave 3