### PR TITLE
Fix: trends:new pub/sub 소비자 연결 (Wave 4 / F3)

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -16,6 +17,7 @@ from backend.api.admin_app import create_admin_app
 from backend.api.middleware.plan_gate import PlanGateMiddleware
 from backend.api.middleware.quota import QuotaMiddleware
 from backend.api.middleware.rate_limit import RateLimitMiddleware
+from backend.api.pubsub.trends_consumer import run_trends_consumer
 from backend.api.routers import (
     auth,
     brand,
@@ -108,7 +110,19 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     scheduler.start()
     logger.info("audit_archive_scheduler_started")
 
+    trends_consumer_task = asyncio.create_task(run_trends_consumer(app.state.db_pool))
+    logger.info("trends_consumer_started")
+
     yield
+
+    trends_consumer_task.cancel()
+    try:
+        await trends_consumer_task
+    except asyncio.CancelledError:
+        pass
+    except Exception as exc:
+        logger.warning("trends_consumer_shutdown_error", error=str(exc))
+    logger.info("trends_consumer_stopped")
 
     scheduler.shutdown(wait=False)
     logger.info("audit_archive_scheduler_stopped")

--- a/backend/api/pubsub/__init__.py
+++ b/backend/api/pubsub/__init__.py
@@ -1,0 +1,1 @@
+"""Background pub/sub consumers for API process."""

--- a/backend/api/pubsub/trends_consumer.py
+++ b/backend/api/pubsub/trends_consumer.py
@@ -1,0 +1,122 @@
+"""Long-running consumer for the `trends:new` Redis pub/sub channel.
+
+On each new group_id:
+  1. Match against notification_keyword (alert_surge=TRUE) and log alerts.
+  2. Invalidate the `feed:*` cache so subsequent /trends queries refresh.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import asyncpg
+import structlog
+
+from backend.db.queries.trends import fetch_trend_detail
+from backend.processor.shared.cache_manager import (
+    get_pubsub_redis,
+    invalidate_feed_cache,
+)
+
+logger = structlog.get_logger(__name__)
+
+_CHANNEL = "trends:new"
+_RECONNECT_DELAY = 5.0
+
+
+async def _match_keyword_alerts(
+    pool: asyncpg.Pool,
+    keywords: list[str],
+) -> list[asyncpg.Record]:
+    """Return notification_keyword rows whose keyword matches (case-insensitive)."""
+    if not keywords:
+        return []
+    lowered = [k.lower() for k in keywords if k]
+    if not lowered:
+        return []
+    try:
+        async with pool.acquire() as conn:
+            return await conn.fetch(
+                """
+                SELECT id::text, user_id::text, keyword
+                FROM notification_keyword
+                WHERE alert_surge = TRUE
+                  AND LOWER(keyword) = ANY($1::text[])
+                """,
+                lowered,
+            )
+    except Exception as exc:
+        logger.warning("keyword_alert_match_failed", error=str(exc))
+        return []
+
+
+async def _handle_message(pool: asyncpg.Pool, group_id: str) -> None:
+    """Process a single `trends:new` message."""
+    try:
+        detail = await fetch_trend_detail(pool, group_id=group_id)
+    except Exception as exc:
+        logger.warning("trends_consumer_fetch_failed", group_id=group_id, error=str(exc))
+        return
+
+    if not detail:
+        logger.debug("trends_consumer_group_not_found", group_id=group_id)
+        return
+
+    group = detail["group"]
+    raw_keywords = group.get("keywords") if isinstance(group, dict) else group["keywords"]
+    keywords: list[str] = list(raw_keywords or [])
+
+    matches = await _match_keyword_alerts(pool, keywords)
+    for row in matches:
+        logger.info(
+            "keyword_alert_triggered",
+            user_id=row["user_id"],
+            keyword=row["keyword"],
+            group_id=group_id,
+        )
+
+    await invalidate_feed_cache()
+
+
+async def run_trends_consumer(pool: asyncpg.Pool) -> None:
+    """Subscribe to `trends:new` forever. Cancels cleanly on task.cancel()."""
+    while True:
+        pubsub = None
+        try:
+            redis = get_pubsub_redis()
+            pubsub = redis.pubsub()
+            await pubsub.subscribe(_CHANNEL)
+            logger.info("trends_consumer_subscribed", channel=_CHANNEL)
+
+            while True:
+                message = await pubsub.get_message(
+                    ignore_subscribe_messages=True,
+                    timeout=30.0,
+                )
+                if not message or message.get("type") != "message":
+                    continue
+                group_id = message["data"]
+                if not isinstance(group_id, str) or not group_id:
+                    logger.warning("trends_consumer_bad_payload", payload=repr(group_id))
+                    continue
+                try:
+                    await _handle_message(pool, group_id)
+                except Exception as exc:
+                    logger.warning(
+                        "trends_consumer_handle_failed",
+                        group_id=group_id,
+                        error=str(exc),
+                    )
+        except asyncio.CancelledError:
+            logger.info("trends_consumer_cancelled")
+            raise
+        except Exception as exc:
+            logger.warning("trends_consumer_loop_error", error=str(exc))
+            await asyncio.sleep(_RECONNECT_DELAY)
+        finally:
+            if pubsub is not None:
+                try:
+                    await pubsub.unsubscribe(_CHANNEL)
+                    await pubsub.aclose()
+                except Exception as cleanup_exc:
+                    logger.debug("trends_consumer_cleanup_error", error=str(cleanup_exc))

--- a/backend/processor/shared/cache_manager.py
+++ b/backend/processor/shared/cache_manager.py
@@ -178,6 +178,31 @@ async def delete_cached(key: str) -> None:
         logger.warning("cache_delete_failed", key=key, error=str(exc))
 
 
+async def delete_keys_by_pattern(pattern: str, *, batch_size: int = 200) -> int:
+    """Scan Redis for keys matching `pattern` and delete them. Returns count."""
+    try:
+        client = get_redis()
+        deleted = 0
+        batch: list[bytes] = []
+        async for key in client.scan_iter(match=pattern, count=batch_size):
+            batch.append(key)
+            if len(batch) >= batch_size:
+                deleted += await client.delete(*batch)
+                batch.clear()
+        if batch:
+            deleted += await client.delete(*batch)
+        logger.info("cache_delete_by_pattern", pattern=pattern, deleted=deleted)
+        return deleted
+    except Exception as exc:
+        logger.warning("cache_delete_by_pattern_failed", pattern=pattern, error=str(exc))
+        return 0
+
+
+async def invalidate_feed_cache() -> int:
+    """Delete all `feed:*` cache entries. Returns number of keys deleted."""
+    return await delete_keys_by_pattern("feed:*")
+
+
 async def acquire_lock(lock_key: str) -> bool:
     """Acquire a SETNX lock for stampede prevention.
 

--- a/tests/test_trends_pubsub_consumer.py
+++ b/tests/test_trends_pubsub_consumer.py
@@ -1,0 +1,221 @@
+"""Tests for the `trends:new` pub/sub consumer and cache invalidation helpers."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from backend.api.pubsub import trends_consumer
+from backend.processor.shared import cache_manager
+
+
+class TestDeleteKeysByPattern:
+    @pytest.mark.asyncio
+    async def test_scans_and_deletes(self) -> None:
+        mock_redis = MagicMock()
+
+        async def _scan_iter(match: str, count: int):  # noqa: ARG001
+            for k in (b"feed:all:all", b"feed:it:ko", b"feed:general:en"):
+                yield k
+
+        mock_redis.scan_iter = _scan_iter
+        mock_redis.delete = AsyncMock(return_value=3)
+
+        with patch.object(cache_manager, "_redis_pool", mock_redis):
+            deleted = await cache_manager.delete_keys_by_pattern("feed:*")
+
+        assert deleted == 3
+        mock_redis.delete.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_on_error(self) -> None:
+        mock_redis = MagicMock()
+
+        def _bad_scan(*_args: object, **_kwargs: object):
+            raise RuntimeError("redis down")
+
+        mock_redis.scan_iter = _bad_scan
+
+        with patch.object(cache_manager, "_redis_pool", mock_redis):
+            result = await cache_manager.delete_keys_by_pattern("feed:*")
+
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_invalidate_feed_cache_uses_feed_prefix(self) -> None:
+        with patch.object(
+            cache_manager,
+            "delete_keys_by_pattern",
+            AsyncMock(return_value=5),
+        ) as mock_delete:
+            result = await cache_manager.invalidate_feed_cache()
+
+        assert result == 5
+        mock_delete.assert_awaited_once_with("feed:*")
+
+
+class TestMatchKeywordAlerts:
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_no_keywords(self) -> None:
+        pool = MagicMock()
+        result = await trends_consumer._match_keyword_alerts(pool, [])
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_queries_with_lowered_keywords(self) -> None:
+        conn = MagicMock()
+        conn.fetch = AsyncMock(return_value=[{"id": "k1", "user_id": "u1", "keyword": "ChatGPT"}])
+        acquire_cm = MagicMock()
+        acquire_cm.__aenter__ = AsyncMock(return_value=conn)
+        acquire_cm.__aexit__ = AsyncMock(return_value=None)
+        pool = MagicMock()
+        pool.acquire = MagicMock(return_value=acquire_cm)
+
+        rows = await trends_consumer._match_keyword_alerts(pool, ["ChatGPT", "AI"])
+
+        conn.fetch.assert_awaited_once()
+        _, args = conn.fetch.await_args
+        # second positional argument is the lowered list
+        assert conn.fetch.await_args.args[1] == ["chatgpt", "ai"]
+        assert rows[0]["keyword"] == "ChatGPT"
+
+
+class TestHandleMessage:
+    @pytest.mark.asyncio
+    async def test_logs_alert_and_invalidates(self) -> None:
+        pool = MagicMock()
+        detail = {
+            "group": {"id": "g-1", "keywords": ["AI", "LLM"]},
+            "articles": [],
+        }
+        with (
+            patch.object(
+                trends_consumer,
+                "fetch_trend_detail",
+                AsyncMock(return_value=detail),
+            ),
+            patch.object(
+                trends_consumer,
+                "_match_keyword_alerts",
+                AsyncMock(return_value=[{"id": "k", "user_id": "u1", "keyword": "AI"}]),
+            ),
+            patch.object(
+                trends_consumer,
+                "invalidate_feed_cache",
+                AsyncMock(return_value=2),
+            ) as mock_invalidate,
+            patch.object(trends_consumer.logger, "info") as mock_info,
+        ):
+            await trends_consumer._handle_message(pool, "g-1")
+
+        mock_invalidate.assert_awaited_once()
+        event_names = [call.args[0] for call in mock_info.call_args_list]
+        assert "keyword_alert_triggered" in event_names
+
+    @pytest.mark.asyncio
+    async def test_skips_when_group_missing(self) -> None:
+        pool = MagicMock()
+        with (
+            patch.object(
+                trends_consumer,
+                "fetch_trend_detail",
+                AsyncMock(return_value=None),
+            ),
+            patch.object(trends_consumer, "invalidate_feed_cache", AsyncMock()) as mock_invalidate,
+        ):
+            await trends_consumer._handle_message(pool, "missing")
+
+        mock_invalidate.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_swallows_fetch_exception(self) -> None:
+        pool = MagicMock()
+        with (
+            patch.object(
+                trends_consumer,
+                "fetch_trend_detail",
+                AsyncMock(side_effect=RuntimeError("db down")),
+            ),
+            patch.object(trends_consumer, "invalidate_feed_cache", AsyncMock()) as mock_invalidate,
+        ):
+            # Must not raise
+            await trends_consumer._handle_message(pool, "g-x")
+
+        mock_invalidate.assert_not_awaited()
+
+
+class TestRunTrendsConsumer:
+    @pytest.mark.asyncio
+    async def test_processes_message_and_cancels(self) -> None:
+        """Consumer should call _handle_message for a real message then exit on cancel."""
+        mock_pubsub = MagicMock()
+        mock_pubsub.subscribe = AsyncMock()
+        mock_pubsub.unsubscribe = AsyncMock()
+        mock_pubsub.aclose = AsyncMock()
+
+        call_count = {"n": 0}
+
+        async def _get_message(*_args: object, **_kwargs: object) -> dict[str, object] | None:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return {"type": "message", "data": "group-abc"}
+            # subsequent calls block until cancelled
+            await asyncio.sleep(3600)
+            return None
+
+        mock_pubsub.get_message = _get_message
+
+        mock_redis = MagicMock()
+        mock_redis.pubsub = MagicMock(return_value=mock_pubsub)
+
+        pool = MagicMock()
+
+        with (
+            patch.object(trends_consumer, "get_pubsub_redis", return_value=mock_redis),
+            patch.object(trends_consumer, "_handle_message", AsyncMock()) as mock_handle,
+        ):
+            task = asyncio.create_task(trends_consumer.run_trends_consumer(pool))
+            # Let the consumer pick up the first message
+            for _ in range(20):
+                if mock_handle.await_count >= 1:
+                    break
+                await asyncio.sleep(0.01)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        mock_handle.assert_awaited_with(pool, "group-abc")
+        mock_pubsub.subscribe.assert_awaited_once_with("trends:new")
+
+    @pytest.mark.asyncio
+    async def test_ignores_malformed_payload(self) -> None:
+        mock_pubsub = MagicMock()
+        mock_pubsub.subscribe = AsyncMock()
+        mock_pubsub.unsubscribe = AsyncMock()
+        mock_pubsub.aclose = AsyncMock()
+
+        seq = iter([{"type": "message", "data": ""}])
+
+        async def _get_message(*_args: object, **_kwargs: object) -> dict[str, object] | None:
+            try:
+                return next(seq)
+            except StopIteration:
+                await asyncio.sleep(3600)
+                return None
+
+        mock_pubsub.get_message = _get_message
+        mock_redis = MagicMock()
+        mock_redis.pubsub = MagicMock(return_value=mock_pubsub)
+
+        with (
+            patch.object(trends_consumer, "get_pubsub_redis", return_value=mock_redis),
+            patch.object(trends_consumer, "_handle_message", AsyncMock()) as mock_handle,
+        ):
+            task = asyncio.create_task(trends_consumer.run_trends_consumer(MagicMock()))
+            await asyncio.sleep(0.05)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        mock_handle.assert_not_awaited()


### PR DESCRIPTION
## Summary
- `backend/api/pubsub/trends_consumer.py` 신규 — `trends:new` 채널 상시 구독, 수신 시 (1) `notification_keyword(alert_surge=TRUE)` 매칭 → structlog 알림 로그, (2) `feed:*` 캐시 무효화
- `cache_manager`에 `delete_keys_by_pattern` / `invalidate_feed_cache` helper 추가 (Redis SCAN+DELETE 배치)
- FastAPI lifespan에서 `asyncio.create_task`로 consumer 등록, shutdown 시 cancel+await
- 테스트 10케이스 추가 (전부 green), 전체 1178 pass / coverage 76.56%

## Test plan
- [x] `pytest tests/test_trends_pubsub_consumer.py -x --no-cov` 10 passed
- [x] 전체 `pytest --cov` 1178 passed, 76.56% 커버리지
- [x] `ruff check` / `ruff format` 통과
- [ ] 수동: `docker compose up` → save publish 발생 시 `keyword_alert_triggered` 로그, `redis-cli KEYS 'feed:*'` empty 확인

Closes #241