### PR TITLE
Fix: score multiplier 영속화 (Wave 5 / F6·F7)

### DIFF
--- a/backend/db/queries/trends.py
+++ b/backend/db/queries/trends.py
@@ -218,6 +218,8 @@ async def fetch_trend_detail(
                        ng.title, ng.summary, ng.score,
                        ng.early_trend_score, ng.keywords,
                        ng.created_at, ng.growth_type,
+                       ng.cross_platform_multiplier,
+                       ng.external_trend_boost,
                        {_DIRECTION_CASE}
                 FROM news_group ng
                 {_DIRECTION_LATERAL}

--- a/backend/processor/stages/save.py
+++ b/backend/processor/stages/save.py
@@ -32,9 +32,11 @@ async def stage_save(
                 group_rows = await conn.fetch(
                     "INSERT INTO news_group "
                     "(category, locale, title, summary, score, "
-                    "early_trend_score, keywords, burst_score) "
+                    "early_trend_score, keywords, burst_score, "
+                    "cross_platform_multiplier, external_trend_boost) "
                     "SELECT * FROM unnest($1::text[], $2::text[], $3::text[], $4::text[], "
-                    "$5::float8[], $6::float8[], $7::text[][], $8::float8[]) "
+                    "$5::float8[], $6::float8[], $7::text[][], $8::float8[], "
+                    "$9::float8[], $10::float8[]) "
                     "RETURNING id",
                     [c["category"] for c in scored_clusters],
                     [c["locale"] for c in scored_clusters],
@@ -44,6 +46,8 @@ async def stage_save(
                     [c.get("early_trend_score", 0.0) for c in scored_clusters],
                     [c["keywords"] for c in scored_clusters],
                     [c.get("burst_score", 0.0) for c in scored_clusters],
+                    [c.get("cross_platform_multiplier", 1.0) for c in scored_clusters],
+                    [c.get("external_trend_boost", 1.0) for c in scored_clusters],
                 )
 
                 # Collect all article UPDATE pairs
@@ -90,8 +94,9 @@ async def _save_individually(
             group_id = await db_pool.fetchval(
                 "INSERT INTO news_group "
                 "(category, locale, title, summary, score, "
-                "early_trend_score, keywords, burst_score) "
-                "VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id",
+                "early_trend_score, keywords, burst_score, "
+                "cross_platform_multiplier, external_trend_boost) "
+                "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING id",
                 item["category"],
                 item["locale"],
                 item["title"],
@@ -100,6 +105,8 @@ async def _save_individually(
                 item.get("early_trend_score", 0.0),
                 item["keywords"],
                 item.get("burst_score", 0.0),
+                item.get("cross_platform_multiplier", 1.0),
+                item.get("external_trend_boost", 1.0),
             )
 
             articles: list[dict[str, Any]] = item.get("articles", [])

--- a/migrations/033_score_multipliers.py
+++ b/migrations/033_score_multipliers.py
@@ -1,0 +1,28 @@
+"""033: Persist cross_platform_multiplier and external_trend_boost on news_group."""
+
+from __future__ import annotations
+
+import asyncpg
+
+VERSION = "033_score_multipliers"
+DESCRIPTION = "Add cross_platform_multiplier / external_trend_boost columns to news_group"
+
+
+async def up(conn: asyncpg.Connection) -> None:
+    await conn.execute(
+        """
+        ALTER TABLE news_group
+        ADD COLUMN IF NOT EXISTS cross_platform_multiplier FLOAT NOT NULL DEFAULT 1.0,
+        ADD COLUMN IF NOT EXISTS external_trend_boost FLOAT NOT NULL DEFAULT 1.0
+        """
+    )
+
+
+async def down(conn: asyncpg.Connection) -> None:
+    await conn.execute(
+        """
+        ALTER TABLE news_group
+        DROP COLUMN IF EXISTS cross_platform_multiplier,
+        DROP COLUMN IF EXISTS external_trend_boost
+        """
+    )

--- a/tests/test_score_multipliers_persist.py
+++ b/tests/test_score_multipliers_persist.py
@@ -1,0 +1,95 @@
+"""Tests for stage_save persisting cross_platform_multiplier / external_trend_boost."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from backend.processor.stages import save as save_stage
+
+
+def _make_cluster(
+    *,
+    cross_platform_multiplier: float = 1.25,
+    external_trend_boost: float = 1.1,
+) -> dict:
+    return {
+        "category": "it",
+        "locale": "ko",
+        "title": "AI 급등",
+        "summary": "요약",
+        "score": 85.5,
+        "early_trend_score": 0.7,
+        "keywords": ["AI", "LLM"],
+        "burst_score": 0.6,
+        "cross_platform_multiplier": cross_platform_multiplier,
+        "external_trend_boost": external_trend_boost,
+        "articles": [{"url_hash": "h1"}],
+    }
+
+
+class TestStageSaveMultipliers:
+    @pytest.mark.asyncio
+    async def test_batch_insert_includes_multipliers(self) -> None:
+        conn = MagicMock()
+        conn.fetch = AsyncMock(return_value=[{"id": "gid-1"}])
+        conn.executemany = AsyncMock()
+
+        tx = MagicMock()
+        tx.__aenter__ = AsyncMock(return_value=None)
+        tx.__aexit__ = AsyncMock(return_value=None)
+        conn.transaction = MagicMock(return_value=tx)
+
+        acquire_cm = MagicMock()
+        acquire_cm.__aenter__ = AsyncMock(return_value=conn)
+        acquire_cm.__aexit__ = AsyncMock(return_value=None)
+        pool = MagicMock()
+        pool.acquire = MagicMock(return_value=acquire_cm)
+
+        cluster = _make_cluster(cross_platform_multiplier=1.25, external_trend_boost=1.1)
+        with patch.object(save_stage, "publish", AsyncMock()):
+            saved = await save_stage.stage_save([cluster], pool)
+
+        assert saved == 1
+        conn.fetch.assert_awaited_once()
+        sql, *args = conn.fetch.await_args.args
+        assert "cross_platform_multiplier" in sql
+        assert "external_trend_boost" in sql
+        # args positions 8,9 correspond to $9,$10 = multiplier/boost lists
+        assert args[8] == [1.25]
+        assert args[9] == [1.1]
+
+    @pytest.mark.asyncio
+    async def test_fallback_insert_includes_multipliers(self) -> None:
+        pool = MagicMock()
+        pool.fetchval = AsyncMock(return_value="gid-2")
+        pool.execute = AsyncMock()
+
+        cluster = _make_cluster(cross_platform_multiplier=0.9, external_trend_boost=1.2)
+        saved = await save_stage._save_individually([cluster], pool)
+
+        assert saved == 1
+        pool.fetchval.assert_awaited_once()
+        sql, *args = pool.fetchval.await_args.args
+        assert "cross_platform_multiplier" in sql
+        assert "external_trend_boost" in sql
+        # ($1..$10) = category, locale, title, summary, score, early, keywords, burst, mult, boost
+        assert args[8] == 0.9
+        assert args[9] == 1.2
+
+    @pytest.mark.asyncio
+    async def test_missing_keys_default_to_one(self) -> None:
+        """Older callers without multiplier keys should default to 1.0 (neutral)."""
+        pool = MagicMock()
+        pool.fetchval = AsyncMock(return_value="gid-3")
+        pool.execute = AsyncMock()
+
+        cluster = _make_cluster()
+        cluster.pop("cross_platform_multiplier")
+        cluster.pop("external_trend_boost")
+
+        await save_stage._save_individually([cluster], pool)
+
+        args = pool.fetchval.await_args.args
+        assert args[-2] == 1.0
+        assert args[-1] == 1.0


### PR DESCRIPTION
## Summary
- `migrations/033_score_multipliers.py` 신규 — `news_group`에 `cross_platform_multiplier`, `external_trend_boost` FLOAT 컬럼 추가 (기본값 1.0 = 중립)
- `backend/processor/stages/save.py`: batch/fallback INSERT 모두 두 값 포함 (미존재 시 1.0 fallback)
- `backend/db/queries/trends.py` `fetch_trend_detail` SELECT 확장 — admin/trend 상세 응답에 노출
- 테스트 3케이스 추가, 전체 1171 pass / 76.72% coverage

## Test plan
- [x] `pytest tests/test_score_multipliers_persist.py -x --no-cov` 3 passed
- [x] 전체 pytest 1171 passed / coverage ≥ 70%
- [x] ruff lint + format 통과
- [ ] 수동: migration 적용 후 새 트렌드 생성 시 컬럼이 1.0 != 값으로 기록되는지 확인

Closes #243