### PR TITLE
Fix: Plan Gate upgradeUrl 반영 / share 성공 toast / export 중앙 핸들러 통일

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -226,6 +226,61 @@ export async function apiRequest<T>(
 	}
 }
 
+export async function apiRequestBlob(
+	path: string,
+	options: RequestOptions = {}
+): Promise<Blob> {
+	const { method = 'GET', body, headers = {}, auth = true } = options;
+	const url = `${API_BASE}${path}`;
+
+	const reqHeaders: Record<string, string> = { ...headers };
+	if (auth) {
+		const token = getAccessToken();
+		if (token) reqHeaders['Authorization'] = `Bearer ${token}`;
+	}
+	if (body !== undefined && !reqHeaders['Content-Type']) {
+		reqHeaders['Content-Type'] = 'application/json';
+	}
+
+	try {
+		let response = await fetch(url, {
+			method,
+			headers: reqHeaders,
+			body: body ? JSON.stringify(body) : undefined
+		});
+
+		if (response.status === 401 && auth) {
+			const refreshed = await refreshAccessToken();
+			if (refreshed) {
+				const newToken = getAccessToken();
+				if (newToken) reqHeaders['Authorization'] = `Bearer ${newToken}`;
+				response = await fetch(url, {
+					method,
+					headers: reqHeaders,
+					body: body ? JSON.stringify(body) : undefined
+				});
+			}
+		}
+
+		if (!response.ok) {
+			await handleErrorResponse(response);
+		}
+
+		return await response.blob();
+	} catch (error) {
+		if (
+			error instanceof ApiRequestError ||
+			error instanceof QuotaExceededRequestError ||
+			error instanceof PlanGateRequestError
+		) {
+			throw error;
+		}
+		throw new NetworkError(
+			error instanceof Error ? error.message : 'Network request failed'
+		);
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Auth helpers
 // ---------------------------------------------------------------------------

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -1,5 +1,6 @@
 export {
 	apiRequest,
+	apiRequestBlob,
 	login,
 	logout,
 	clearTokens,

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -498,6 +498,7 @@
 	"trends.export.pdf": "Download PDF",
 	"trends.share.button": "Share Link",
 	"trends.share.copied": "Link copied.",
+	"toast.success.default": "Done.",
 	"trends.share.error": "Failed to generate link.",
 	"trends.map.title": "Trend Map",
 	"trends.map.empty": "No related trend data available.",

--- a/frontend/src/lib/i18n/ko.json
+++ b/frontend/src/lib/i18n/ko.json
@@ -498,6 +498,7 @@
 	"trends.export.pdf": "PDF 다운로드",
 	"trends.share.button": "공유 링크",
 	"trends.share.copied": "링크가 복사되었습니다.",
+	"toast.success.default": "완료되었습니다.",
 	"trends.share.error": "링크 생성에 실패했습니다.",
 	"trends.map.title": "트렌드 맵",
 	"trends.map.empty": "관련 트렌드 데이터가 없습니다.",

--- a/frontend/src/lib/ui/PlanGate.svelte
+++ b/frontend/src/lib/ui/PlanGate.svelte
@@ -6,10 +6,11 @@
 	interface Props {
 		open: boolean;
 		requiredPlan?: string;
+		upgradeUrl?: string;
 		onClose: () => void;
 	}
 
-	let { open, requiredPlan = 'pro', onClose }: Props = $props();
+	let { open, requiredPlan = 'pro', upgradeUrl = '/pricing', onClose }: Props = $props();
 
 	let dialogEl: HTMLDivElement | undefined = $state();
 
@@ -64,7 +65,7 @@
 
 			<div class="mt-6 flex gap-3 justify-end">
 				<a
-					href="/pricing"
+					href={upgradeUrl}
 					class="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
 				>
 					{$t('modal.plan_required.upgrade')}

--- a/frontend/src/lib/ui/SuccessToast.svelte
+++ b/frontend/src/lib/ui/SuccessToast.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import { t } from 'svelte-i18n';
+	import { CheckCircle2, X } from 'lucide-svelte';
+
+	interface Props {
+		open: boolean;
+		messageKey?: string;
+		durationMs?: number;
+		onClose: () => void;
+	}
+
+	let { open, messageKey = 'toast.success.default', durationMs = 3000, onClose }: Props = $props();
+
+	let timer: ReturnType<typeof setTimeout> | undefined;
+
+	$effect(() => {
+		if (open) {
+			timer = setTimeout(onClose, durationMs);
+			return () => {
+				if (timer) clearTimeout(timer);
+			};
+		}
+	});
+</script>
+
+{#if open}
+	<div
+		class="pointer-events-none fixed inset-x-0 bottom-6 z-50 flex justify-center"
+		role="status"
+		aria-live="polite"
+	>
+		<div
+			class="pointer-events-auto flex items-center gap-3 rounded-lg bg-green-600 px-4 py-3 text-sm font-medium text-white shadow-lg"
+		>
+			<CheckCircle2 size={18} />
+			<span>{$t(messageKey)}</span>
+			<button
+				onclick={onClose}
+				class="ml-2 text-white/80 hover:text-white"
+				aria-label={$t('a11y.close_dialog')}
+			>
+				<X size={16} />
+			</button>
+		</div>
+	</div>
+{/if}

--- a/frontend/src/routes/compare/+page.svelte
+++ b/frontend/src/routes/compare/+page.svelte
@@ -36,6 +36,7 @@
 	let isLoading = $state(false);
 	let errorMessage = $state('');
 	let showPlanGate = $state(false);
+	let planGateUpgradeUrl = $state('/pricing');
 
 	// Titles for selected trends (fetched when loading from URL)
 	let trendTitles = $state<Record<string, string>>({});
@@ -127,6 +128,7 @@
 			}
 		} catch (err) {
 			if (err instanceof PlanGateRequestError) {
+				planGateUpgradeUrl = err.upgradeUrl ?? '/pricing';
 				showPlanGate = true;
 				compareData = [];
 			} else {
@@ -253,4 +255,4 @@
 	{/if}
 </div>
 
-<PlanGate open={showPlanGate} requiredPlan="pro" onClose={() => (showPlanGate = false)} />
+<PlanGate open={showPlanGate} requiredPlan="pro" upgradeUrl={planGateUpgradeUrl} onClose={() => (showPlanGate = false)} />

--- a/frontend/src/routes/content/+page.svelte
+++ b/frontend/src/routes/content/+page.svelte
@@ -26,6 +26,7 @@
 
 	let planGateOpen = $state(false);
 	let planGateRequired = $state('pro');
+	let planGateUpgradeUrl = $state('/pricing');
 
 	const isFreePlan = $derived(authStore.user?.plan === 'free');
 
@@ -49,6 +50,7 @@
 		} catch (error) {
 			if (error instanceof PlanGateRequestError) {
 				planGateRequired = error.requiredPlan;
+				planGateUpgradeUrl = error.upgradeUrl ?? '/pricing';
 				planGateOpen = true;
 			} else if (error instanceof ApiRequestError) {
 				showError(error.errorCode, 'error.server');
@@ -126,7 +128,7 @@
 	</PageStateWrapper>
 </div>
 
-<PlanGate open={planGateOpen} requiredPlan={planGateRequired} onClose={() => (planGateOpen = false)} />
+<PlanGate open={planGateOpen} requiredPlan={planGateRequired} upgradeUrl={planGateUpgradeUrl} onClose={() => (planGateOpen = false)} />
 <ErrorModal
 	open={errorOpen}
 	errorCode={errorCode}

--- a/frontend/src/routes/trends/+page.svelte
+++ b/frontend/src/routes/trends/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { t } from 'svelte-i18n';
 	import { onMount } from 'svelte';
-	import { apiRequest, ApiRequestError, QuotaExceededRequestError, PlanGateRequestError } from '$lib/api';
+	import { apiRequest, apiRequestBlob, ApiRequestError, QuotaExceededRequestError, PlanGateRequestError } from '$lib/api';
 	import type { TrendListResponse, TrendItem } from '$lib/api';
 	import { createPaginationStore } from '$lib/stores/pagination.svelte';
 	import { createFilterStore } from '$lib/stores/filters.svelte';
@@ -14,6 +14,7 @@
 	import ErrorModal from '$lib/ui/ErrorModal.svelte';
 	import QuotaExceededModal from '$lib/ui/QuotaExceededModal.svelte';
 	import PlanGate from '$lib/ui/PlanGate.svelte';
+	import SuccessToast from '$lib/ui/SuccessToast.svelte';
 	import FilterButton from '$lib/ui/FilterButton.svelte';
 	import MultiSelect from '$lib/components/MultiSelect.svelte';
 	import PageStateWrapper from '$lib/ui/PageStateWrapper.svelte';
@@ -62,6 +63,9 @@
 
 	let planGateOpen = $state(false);
 	let planGateRequired = $state('pro');
+	let planGateUpgradeUrl = $state('/pricing');
+
+	let shareSuccessOpen = $state(false);
 
 	let isExportingCsv = $state(false);
 	let isExportingPdf = $state(false);
@@ -147,8 +151,9 @@
 		}
 	}
 
-	function showPlanGate(plan: string): void {
+	function showPlanGate(plan: string, upgradeUrl?: string): void {
 		planGateRequired = plan;
+		planGateUpgradeUrl = upgradeUrl ?? '/pricing';
 		planGateOpen = true;
 	}
 
@@ -159,36 +164,19 @@
 			isExportingPdf = true;
 		}
 		try {
-			const response = await fetch(
-				`${import.meta.env.VITE_API_BASE_URL ?? '/api/v1'}/trends/export?format=${format}`,
-				{
-					headers: {
-						Authorization: `Bearer ${localStorage.getItem('access_token') ?? ''}`,
-					},
-				}
-			);
-			if (response.status === 402 || response.status === 403) {
-				const body = await response.json().catch(() => ({}));
-				showPlanGate(body.required_plan ?? 'pro');
-				return;
-			}
-			if (!response.ok) {
-				errorCode = 'ERR_EXPORT';
-				errorMessageKey = 'error.server';
-				errorOpen = true;
-				return;
-			}
-			const blob = await response.blob();
+			const blob = await apiRequestBlob(`/trends/export?format=${format}`);
 			const url = URL.createObjectURL(blob);
 			const a = document.createElement('a');
 			a.href = url;
 			a.download = `trends.${format}`;
 			a.click();
 			URL.revokeObjectURL(url);
-		} catch {
-			errorCode = 'ERR_NETWORK';
-			errorMessageKey = 'error.network';
-			errorOpen = true;
+		} catch (error) {
+			if (error instanceof PlanGateRequestError) {
+				showPlanGate(error.requiredPlan, error.upgradeUrl);
+			} else {
+				handleError(error);
+			}
 		} finally {
 			isExportingCsv = false;
 			isExportingPdf = false;
@@ -215,12 +203,10 @@
 			});
 			const fullUrl = `${window.location.origin}${data.share_url}?utm_source=trendscope&utm_medium=share&utm_campaign=trend_share`;
 			await navigator.clipboard.writeText(fullUrl);
-			errorCode = '';
-			errorMessageKey = 'trends.share.copied';
-			errorOpen = true;
+			shareSuccessOpen = true;
 		} catch (error) {
 			if (error instanceof PlanGateRequestError) {
-				showPlanGate(error.requiredPlan);
+				showPlanGate(error.requiredPlan, error.upgradeUrl);
 			} else if (error instanceof ApiRequestError) {
 				errorCode = error.errorCode;
 				errorMessageKey = 'trends.share.error';
@@ -484,6 +470,7 @@
 	{/if}
 </div>
 
-<PlanGate open={planGateOpen} requiredPlan={planGateRequired} onClose={() => (planGateOpen = false)} />
+<PlanGate open={planGateOpen} requiredPlan={planGateRequired} upgradeUrl={planGateUpgradeUrl} onClose={() => (planGateOpen = false)} />
 <ErrorModal open={errorOpen} errorCode={errorCode} messageKey={errorMessageKey} onClose={() => (errorOpen = false)} onRetry={() => { errorOpen = false; loadTrends(); }} />
 <QuotaExceededModal open={quotaOpen} feature={quotaFeature} limit={quotaLimit} resetTime={quotaResetTime} onClose={() => (quotaOpen = false)} />
+<SuccessToast open={shareSuccessOpen} messageKey="trends.share.copied" onClose={() => (shareSuccessOpen = false)} />

--- a/frontend/src/routes/trends/[id]/+page.svelte
+++ b/frontend/src/routes/trends/[id]/+page.svelte
@@ -52,6 +52,7 @@
 	let isForecastLoading = $state(false);
 	let planGateOpen = $state(false);
 	let planGateRequired = $state('pro');
+	let planGateUpgradeUrl = $state('/pricing');
 
 	let articleTab = $state<'all' | 'by_source'>('all');
 	let expandedSources = $state<Set<string>>(new Set());
@@ -94,6 +95,7 @@
 		} catch (error) {
 			if (error instanceof PlanGateRequestError) {
 				planGateRequired = error.requiredPlan;
+				planGateUpgradeUrl = error.upgradeUrl ?? '/pricing';
 				planGateOpen = true;
 			}
 			forecastData = [];
@@ -377,5 +379,5 @@
 	{/if}
 </div>
 
-<PlanGate open={planGateOpen} requiredPlan={planGateRequired} onClose={() => (planGateOpen = false)} />
+<PlanGate open={planGateOpen} requiredPlan={planGateRequired} upgradeUrl={planGateUpgradeUrl} onClose={() => (planGateOpen = false)} />
 <ErrorModal open={errorOpen} errorCode={errorCode} messageKey={errorMessageKey} onClose={() => (errorOpen = false)} onRetry={() => { errorOpen = false; loadDetail(); }} />

--- a/frontend/src/routes/trends/[id]/insights/+page.svelte
+++ b/frontend/src/routes/trends/[id]/insights/+page.svelte
@@ -20,6 +20,7 @@
 
 	let planGateOpen = $state(false);
 	let requiredPlan = $state('pro');
+	let planGateUpgradeUrl = $state('/pricing');
 
 	const groupId = $derived(page.params.id ?? '');
 	const userRole = $derived(authStore.user?.role ?? 'general');
@@ -34,6 +35,7 @@
 		} catch (error) {
 			if (error instanceof PlanGateRequestError) {
 				requiredPlan = error.requiredPlan;
+				planGateUpgradeUrl = error.upgradeUrl ?? '/pricing';
 				planGateOpen = true;
 			} else if (error instanceof ApiRequestError) {
 				errorCode = error.errorCode;
@@ -294,4 +296,4 @@
 </div>
 
 <ErrorModal open={errorOpen} errorCode={errorCode} messageKey={errorMessageKey} onClose={() => (errorOpen = false)} onRetry={() => { errorOpen = false; loadInsight(); }} />
-<PlanGate open={planGateOpen} requiredPlan={requiredPlan} onClose={() => (planGateOpen = false)} />
+<PlanGate open={planGateOpen} requiredPlan={requiredPlan} upgradeUrl={planGateUpgradeUrl} onClose={() => (planGateOpen = false)} />


### PR DESCRIPTION
## Summary
- PlanGate `upgradeUrl` prop 반영, 모든 catch 지점에서 `PlanGateRequestError.upgradeUrl` 전파 (F8)
- 공유 링크 복사 성공을 `SuccessToast` 신규 컴포넌트로 분리, ErrorModal 오용 제거 (F9)
- `/trends/export`를 `apiRequestBlob` 경유로 이동해 중앙 에러 핸들러 통일 (F11)
- `toast.success.default` i18n 키 en/ko 추가

## Test plan
- [x] 기존 svelte-check 에러 증가 없음 (pre-existing 9건만 남음)
- [x] pytest 1168 pass / coverage 76.57%
- [x] ruff lint / format clean
- [ ] 수동: 유료 기능 호출 시 PlanGate 상의 "업그레이드" 버튼이 서버가 준 동적 URL로 이동
- [ ] 수동: 공유 버튼 클릭 → 초록색 토스트 3초 후 자동 사라짐
- [ ] 수동: CSV/PDF export 실패 시 ErrorModal이 표시

Closes #245