### PR TITLE
Fix: Personalization 저장 시 trends 피드 자동 재로딩

### DIFF
--- a/frontend/src/lib/stores/personalization.svelte.ts
+++ b/frontend/src/lib/stores/personalization.svelte.ts
@@ -1,0 +1,33 @@
+/**
+ * Personalization store: shares user's personalization settings across pages
+ * and broadcasts changes so dependent feeds (e.g. /trends) reload automatically.
+ */
+
+export interface PersonalizationSettings {
+	category_weights: { tech: number; finance: number; entertainment: number; lifestyle: number };
+	locale_ratio: number;
+}
+
+function createPersonalizationStore() {
+	let settings = $state<PersonalizationSettings | null>(null);
+	let version = $state(0);
+
+	function set(next: PersonalizationSettings): void {
+		settings = next;
+		version += 1;
+	}
+
+	function clear(): void {
+		settings = null;
+		version += 1;
+	}
+
+	return {
+		get settings() { return settings; },
+		get version() { return version; },
+		set,
+		clear,
+	};
+}
+
+export const personalizationStore = createPersonalizationStore();

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -9,6 +9,7 @@
 	import { X } from 'lucide-svelte';
 	import { Sun, Moon, Monitor } from 'lucide-svelte';
 	import { themeStore } from '$lib/stores/theme.svelte';
+	import { personalizationStore } from '$lib/stores/personalization.svelte';
 
 	type Tab = 'account' | 'plan' | 'notifications' | 'security' | 'personalization' | 'appearance';
 	let activeTab = $state<Tab>('account');
@@ -243,6 +244,7 @@
 		try {
 			const data = await apiRequest<PersonalizationSettings>('/personalization');
 			personalization = data;
+			personalizationStore.set(data);
 		} catch {
 			// Non-critical — silently ignore
 		} finally {
@@ -254,6 +256,7 @@
 		isSavingPersonalization = true;
 		try {
 			await apiRequest('/personalization', { method: 'PUT', body: personalization });
+			personalizationStore.set(personalization);
 		} catch (error) {
 			if (error instanceof ApiRequestError) {
 				showError(error.errorCode, 'error.server');
@@ -284,6 +287,7 @@
 				category_weights: result.category_weights as PersonalizationSettings['category_weights'],
 				locale_ratio: result.locale_ratio,
 			};
+			personalizationStore.set(personalization);
 		} catch (error) {
 			if (error instanceof ApiRequestError) {
 				showError(error.errorCode, 'settings.behavior.apply_error');

--- a/frontend/src/routes/trends/+page.svelte
+++ b/frontend/src/routes/trends/+page.svelte
@@ -6,6 +6,7 @@
 	import { createPaginationStore } from '$lib/stores/pagination.svelte';
 	import { createFilterStore } from '$lib/stores/filters.svelte';
 	import { createCacheStore } from '$lib/stores/cache.svelte';
+	import { personalizationStore } from '$lib/stores/personalization.svelte';
 	import type { FetchFn } from '$lib/stores/pagination.svelte';
 	import TrendCard from '../../components/TrendCard.svelte';
 	import SkeletonCard from '../../components/SkeletonCard.svelte';
@@ -299,12 +300,30 @@
 	}
 
 	onMount(async () => {
-		try {
-			personalization = await apiRequest<PersonalizationSettings>('/personalization');
-		} catch {
-			// Non-critical — proceed without personalization
+		if (personalizationStore.settings) {
+			personalization = personalizationStore.settings;
+		} else {
+			try {
+				const data = await apiRequest<PersonalizationSettings>('/personalization');
+				personalization = data;
+				personalizationStore.set(data);
+			} catch {
+				// Non-critical — proceed without personalization
+			}
 		}
 		await loadTrends();
+	});
+
+	let lastSeenVersion = personalizationStore.version;
+	$effect(() => {
+		const current = personalizationStore.version;
+		if (current !== lastSeenVersion) {
+			lastSeenVersion = current;
+			personalization = personalizationStore.settings;
+			pagination.reset();
+			cache.clear();
+			loadTrends();
+		}
 	});
 </script>
 


### PR DESCRIPTION
## Summary
- personalizationStore 신규 (Svelte 5 runes, version broadcast)
- settings 저장 시 store.set → trends 페이지가 $effect으로 즉시 재로딩
- trends onMount는 store 캐시 우선 사용

Closes #247