### PR TITLE
Chore: processor/crawler 헬스체크 · Alertmanager 활성화 · nginx compose 내 렌더링

### DIFF
--- a/backend/Dockerfile.crawler
+++ b/backend/Dockerfile.crawler
@@ -23,4 +23,7 @@ ENV PYTHONUNBUFFERED=1 \
 
 USER appuser
 
+HEALTHCHECK --interval=60s --timeout=10s --start-period=45s --retries=3 \
+    CMD python -c "import os,sys,time; p=os.environ.get('HEARTBEAT_PATH','/tmp/heartbeat'); sys.exit(0 if os.path.exists(p) and time.time()-os.path.getmtime(p)<180 else 1)"
+
 CMD ["python", "-m", "backend.crawler.main"]

--- a/backend/Dockerfile.processor
+++ b/backend/Dockerfile.processor
@@ -41,4 +41,7 @@ ENV PYTHONUNBUFFERED=1 \
 
 USER appuser
 
+HEALTHCHECK --interval=60s --timeout=10s --start-period=60s --retries=3 \
+    CMD python -c "import os,sys,time; p=os.environ.get('HEARTBEAT_PATH','/tmp/heartbeat'); sys.exit(0 if os.path.exists(p) and time.time()-os.path.getmtime(p)<180 else 1)"
+
 CMD ["python", "-m", "backend.processor.main"]

--- a/backend/common/heartbeat.py
+++ b/backend/common/heartbeat.py
@@ -1,0 +1,43 @@
+"""Heartbeat helper for long-running services without HTTP endpoints.
+
+Writes a sentinel file at a fixed cadence so container orchestrators (Docker
+HEALTHCHECK) can distinguish a live event loop from a hung process.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+HEARTBEAT_PATH = Path(os.environ.get("HEARTBEAT_PATH", "/tmp/heartbeat"))  # noqa: S108
+_DEFAULT_INTERVAL_SECONDS = 30
+
+
+def touch_heartbeat(path: Path = HEARTBEAT_PATH) -> None:
+    """Bump the heartbeat file's mtime; create it if missing."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch(exist_ok=True)
+        os.utime(path, None)
+    except OSError as exc:
+        logger.warning("heartbeat_touch_failed", path=str(path), error=str(exc))
+
+
+async def run_heartbeat(
+    stop_event: asyncio.Event,
+    *,
+    interval_seconds: int = _DEFAULT_INTERVAL_SECONDS,
+    path: Path = HEARTBEAT_PATH,
+) -> None:
+    """Periodically refresh the heartbeat file until stop_event is set."""
+    touch_heartbeat(path)
+    while not stop_event.is_set():
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=interval_seconds)
+        except TimeoutError:
+            touch_heartbeat(path)

--- a/backend/crawler/main.py
+++ b/backend/crawler/main.py
@@ -9,6 +9,7 @@ import signal
 import asyncpg
 import structlog
 
+from backend.common.heartbeat import run_heartbeat
 from backend.common.logging_config import setup_logging
 from backend.crawler.scheduler import create_scheduler, start_scheduler, stop_scheduler
 from backend.crawler.sources.news_crawler import crawl_all as news_crawl_all
@@ -53,7 +54,13 @@ async def main() -> None:
         loop.add_signal_handler(sig, _handle_signal)
 
     logger.info("crawler_running")
+    heartbeat_task = asyncio.create_task(run_heartbeat(stop_event))
     await stop_event.wait()
+    heartbeat_task.cancel()
+    try:
+        await heartbeat_task
+    except asyncio.CancelledError:
+        pass
 
     await stop_scheduler(scheduler)
     await close_redis()

--- a/backend/processor/main.py
+++ b/backend/processor/main.py
@@ -10,6 +10,7 @@ from typing import Any
 import asyncpg
 import structlog
 
+from backend.common.heartbeat import run_heartbeat
 from backend.common.logging_config import setup_logging
 from backend.processor.pipeline import process_articles
 from backend.processor.shared.cache_manager import (
@@ -86,7 +87,13 @@ async def main() -> None:
         loop.add_signal_handler(sig, _handle_signal)
 
     logger.info("processor_running")
+    heartbeat_task = asyncio.create_task(run_heartbeat(stop_event))
     await _poll_loop(db_pool, stop_event)
+    heartbeat_task.cancel()
+    try:
+        await heartbeat_task
+    except asyncio.CancelledError:
+        pass
 
     await close_pubsub()
     await close_redis()

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -50,11 +50,18 @@ services:
     env_file: .env
     environment:
       - APP_ENV=production
+      - HEARTBEAT_PATH=/tmp/heartbeat
     depends_on:
       postgres:
         condition: service_healthy
       redis:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import os,sys,time; p=os.environ.get('HEARTBEAT_PATH','/tmp/heartbeat'); sys.exit(0 if os.path.exists(p) and time.time()-os.path.getmtime(p)<180 else 1)"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
     networks:
       - trendscope-net
 
@@ -65,11 +72,18 @@ services:
     env_file: .env
     environment:
       - APP_ENV=production
+      - HEARTBEAT_PATH=/tmp/heartbeat
     depends_on:
       postgres:
         condition: service_healthy
       redis:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import os,sys,time; p=os.environ.get('HEARTBEAT_PATH','/tmp/heartbeat'); sys.exit(0 if os.path.exists(p) and time.time()-os.path.getmtime(p)<180 else 1)"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 45s
     networks:
       - trendscope-net
 
@@ -89,14 +103,19 @@ services:
     image: nginx:1.25-alpine
     container_name: trendscope-nginx
     restart: unless-stopped
+    environment:
+      - DOMAIN=${DOMAIN}
     ports:
       - "80:80"
       - "443:443"
     volumes:
-      - ./infra/nginx/nginx.prod.conf:/etc/nginx/nginx.conf:ro
+      - ./infra/nginx/nginx.prod.conf.template:/etc/nginx/nginx.prod.conf.template:ro
       - ./infra/nginx/upstream.conf:/etc/nginx/conf.d/upstream.conf
       - /etc/letsencrypt:/etc/letsencrypt:ro
       - /var/www/certbot:/var/www/certbot:ro
+    command: >
+      /bin/sh -c "envsubst '$$DOMAIN' < /etc/nginx/nginx.prod.conf.template > /etc/nginx/nginx.conf
+      && exec nginx -g 'daemon off;'"
     networks:
       - trendscope-net
 
@@ -146,6 +165,22 @@ services:
     networks:
       - trendscope-net
 
+  alertmanager:
+    image: prom/alertmanager:latest
+    container_name: trendscope-alertmanager
+    restart: unless-stopped
+    env_file: .env
+    volumes:
+      - ./infra/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - alertmanager-data:/alertmanager
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.yml"
+      - "--storage.path=/alertmanager"
+    depends_on:
+      - prometheus
+    networks:
+      - trendscope-net
+
   grafana:
     image: grafana/grafana:latest
     container_name: trendscope-grafana
@@ -167,6 +202,7 @@ volumes:
   redis-data:
   prometheus-data:
   grafana-data:
+  alertmanager-data:
 
 networks:
   trendscope-net:

--- a/infra/alertmanager/alertmanager.yml
+++ b/infra/alertmanager/alertmanager.yml
@@ -1,0 +1,42 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: default
+  group_by: ["alertname", "severity"]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  routes:
+    - matchers:
+        - severity="critical"
+      receiver: slack-critical
+      continue: true
+
+receivers:
+  - name: default
+    slack_configs:
+      - api_url: "${SLACK_WEBHOOK_URL}"
+        channel: "#trendscope-alerts"
+        send_resolved: true
+        title: "[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}"
+        text: |
+          {{ range .Alerts -}}
+          *Severity*: {{ .Labels.severity }}
+          *Summary*: {{ .Annotations.summary }}
+          *Description*: {{ .Annotations.description }}
+          {{ end }}
+
+  - name: slack-critical
+    slack_configs:
+      - api_url: "${SLACK_WEBHOOK_URL_CRITICAL:-${SLACK_WEBHOOK_URL}}"
+        channel: "#trendscope-critical"
+        send_resolved: true
+        title: "[CRITICAL] {{ .CommonLabels.alertname }}"
+
+inhibit_rules:
+  - source_matchers:
+      - severity="critical"
+    target_matchers:
+      - severity="warning"
+    equal: ["alertname", "service"]

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -3,11 +3,10 @@ global:
   evaluation_interval: 15s
   scrape_timeout: 10s
 
-# TODO: alertmanager 배포 후 아래 주석 해제
-# alerting:
-#   alertmanagers:
-#     - static_configs:
-#         - targets: ["alertmanager:9093"]
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
 
 rule_files:
   - "alert.rules.yml"

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1,0 +1,52 @@
+"""Heartbeat helper unit tests."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from backend.common.heartbeat import run_heartbeat, touch_heartbeat
+
+
+class TestTouchHeartbeat:
+    def test_creates_missing_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "hb"
+        assert not target.exists()
+        touch_heartbeat(target)
+        assert target.exists()
+
+    def test_refreshes_mtime(self, tmp_path: Path) -> None:
+        target = tmp_path / "hb"
+        touch_heartbeat(target)
+        first = target.stat().st_mtime
+        import os
+
+        os.utime(target, (first - 100, first - 100))
+        touch_heartbeat(target)
+        assert target.stat().st_mtime > first - 100
+
+
+@pytest.mark.asyncio
+async def test_run_heartbeat_refreshes_until_stop(tmp_path: Path) -> None:
+    target = tmp_path / "hb"
+    stop = asyncio.Event()
+    task = asyncio.create_task(run_heartbeat(stop, interval_seconds=1, path=target))
+    await asyncio.sleep(2.2)
+    assert target.exists()
+    mtime1 = target.stat().st_mtime
+    await asyncio.sleep(1.2)
+    mtime2 = target.stat().st_mtime
+    assert mtime2 > mtime1
+    stop.set()
+    await task
+
+
+@pytest.mark.asyncio
+async def test_run_heartbeat_stops_on_event(tmp_path: Path) -> None:
+    target = tmp_path / "hb"
+    stop = asyncio.Event()
+    task = asyncio.create_task(run_heartbeat(stop, interval_seconds=5, path=target))
+    await asyncio.sleep(0.1)
+    stop.set()
+    await asyncio.wait_for(task, timeout=1.0)

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,0 @@
-version = 1
-revision = 3
-requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- processor/crawler에 heartbeat 파일 기반 HEALTHCHECK 추가 (`backend/common/heartbeat.py`)
- Alertmanager 서비스 `docker-compose.prod.yml`에 추가 + Slack receivers 설정
- nginx 템플릿을 compose entrypoint에서 `envsubst`로 렌더링 (deploy.sh 의존 제거)
- Prometheus alerting 블록 활성화 (`alertmanager:9093` 타겟)

## Test plan
- [x] pytest (1172 passed / 4 skipped / coverage 76.49%)
- [x] ruff check + format
- [x] `tests/test_heartbeat.py` 4 케이스 통과

Closes #249