### PR TITLE
Fix: 프로덕션에서 QUOTA_DISABLED·RATE_LIMIT_DISABLED kill-switch 무시

### DIFF
--- a/backend/api/middleware/quota.py
+++ b/backend/api/middleware/quota.py
@@ -97,7 +97,11 @@ class QuotaMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
 
     async def dispatch(self, request: Request, call_next):  # noqa: ANN001, ANN201
-        if os.environ.get("QUOTA_DISABLED", "false").lower() == "true":
+        disabled = os.environ.get("QUOTA_DISABLED", "false").lower() == "true"
+        is_production = os.environ.get("APP_ENV", "").lower() == "production"
+        if disabled and is_production:
+            logger.warning("quota_disabled_ignored_in_production")
+        elif disabled:
             return await call_next(request)
         try:
             if request.method not in _GATED_METHODS:

--- a/backend/api/middleware/rate_limit.py
+++ b/backend/api/middleware/rate_limit.py
@@ -51,7 +51,11 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
 
     async def dispatch(self, request: Request, call_next):  # noqa: ANN001, ANN201
-        if os.environ.get("RATE_LIMIT_DISABLED", "false").lower() == "true":
+        disabled = os.environ.get("RATE_LIMIT_DISABLED", "false").lower() == "true"
+        is_production = os.environ.get("APP_ENV", "").lower() == "production"
+        if disabled and is_production:
+            logger.warning("rate_limit_disabled_ignored_in_production")
+        elif disabled:
             return await call_next(request)
         try:
             path = request.url.path

--- a/tests/test_middleware_quota.py
+++ b/tests/test_middleware_quota.py
@@ -205,3 +205,23 @@ class TestQuotaMiddlewareIntegration:
         # health doesn't have DELETE but middleware skips before routing
         # 405 is fine — the middleware didn't block it with 429
         assert resp.status_code != 429
+
+    async def test_quota_disabled_env_bypasses_in_non_production(
+        self, client, mini_app, monkeypatch
+    ) -> None:  # noqa: ANN001
+        monkeypatch.setenv("QUOTA_DISABLED", "true")
+        monkeypatch.delenv("APP_ENV", raising=False)
+        mini_app.state.db_pool = _make_db_pool(usage_count=999)
+        token = _make_token("u1", "free")
+        resp = await client.get("/api/v1/trends", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+
+    async def test_quota_disabled_env_ignored_in_production(
+        self, client, mini_app, monkeypatch
+    ) -> None:  # noqa: ANN001
+        monkeypatch.setenv("QUOTA_DISABLED", "true")
+        monkeypatch.setenv("APP_ENV", "production")
+        mini_app.state.db_pool = _make_db_pool(usage_count=10)
+        token = _make_token("u1", "free")
+        resp = await client.get("/api/v1/trends", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 429

--- a/tests/test_middleware_rate_limit.py
+++ b/tests/test_middleware_rate_limit.py
@@ -161,3 +161,21 @@ class TestRateLimitMiddlewareIntegration:
             resp = await client.get("/api/v1/trends")
         assert resp.status_code == 429
         assert int(resp.headers["Retry-After"]) >= 1
+
+    async def test_rate_limit_disabled_env_bypasses_in_non_production(
+        self, client, monkeypatch
+    ) -> None:  # noqa: ANN001
+        monkeypatch.setenv("RATE_LIMIT_DISABLED", "true")
+        monkeypatch.delenv("APP_ENV", raising=False)
+        redis_mock = _make_redis_mock(current_count=9999, ttl=45)
+        with patch("backend.api.middleware.rate_limit.get_redis", return_value=redis_mock):
+            resp = await client.get("/api/v1/trends")
+        assert resp.status_code == 200
+
+    async def test_rate_limit_disabled_env_ignored_in_production(self, client, monkeypatch) -> None:  # noqa: ANN001
+        monkeypatch.setenv("RATE_LIMIT_DISABLED", "true")
+        monkeypatch.setenv("APP_ENV", "production")
+        redis_mock = _make_redis_mock(current_count=60, ttl=45)
+        with patch("backend.api.middleware.rate_limit.get_redis", return_value=redis_mock):
+            resp = await client.get("/api/v1/trends")
+        assert resp.status_code == 429


### PR DESCRIPTION
## Summary
- `APP_ENV=production`일 때 `QUOTA_DISABLED` / `RATE_LIMIT_DISABLED` ENV kill-switch 무시
- 프로덕션에서 kill-switch가 켜지면 WARNING 로그로 감사 가시성 확보
- 비-production 환경은 기존 동작 유지

## Test plan
- [x] pytest (1172 passed / 76.61% coverage)
- [x] ruff check + format
- [x] 미들웨어 통합 테스트 4건 추가 (production ignored / non-production bypass)

Closes #251