### PR TITLE
Fix: growth_type 분류기 연결 및 DB 영속화 (Wave A)

### DIFF
--- a/backend/db/migrations/023_add_growth_type.sql
+++ b/backend/db/migrations/023_add_growth_type.sql
@@ -1,0 +1,3 @@
+-- Migration 023: growth_type classification column (spike / growth / unknown)
+ALTER TABLE news_group
+    ADD COLUMN IF NOT EXISTS growth_type TEXT NOT NULL DEFAULT 'unknown';

--- a/backend/processor/stages/save.py
+++ b/backend/processor/stages/save.py
@@ -33,10 +33,10 @@ async def stage_save(
                     "INSERT INTO news_group "
                     "(category, locale, title, summary, score, "
                     "early_trend_score, keywords, burst_score, "
-                    "cross_platform_multiplier, external_trend_boost) "
+                    "cross_platform_multiplier, external_trend_boost, growth_type) "
                     "SELECT * FROM unnest($1::text[], $2::text[], $3::text[], $4::text[], "
                     "$5::float8[], $6::float8[], $7::text[][], $8::float8[], "
-                    "$9::float8[], $10::float8[]) "
+                    "$9::float8[], $10::float8[], $11::text[]) "
                     "RETURNING id",
                     [c["category"] for c in scored_clusters],
                     [c["locale"] for c in scored_clusters],
@@ -48,6 +48,7 @@ async def stage_save(
                     [c.get("burst_score", 0.0) for c in scored_clusters],
                     [c.get("cross_platform_multiplier", 1.0) for c in scored_clusters],
                     [c.get("external_trend_boost", 1.0) for c in scored_clusters],
+                    [c.get("growth_type", "unknown") for c in scored_clusters],
                 )
 
                 # Collect all article UPDATE pairs
@@ -95,8 +96,8 @@ async def _save_individually(
                 "INSERT INTO news_group "
                 "(category, locale, title, summary, score, "
                 "early_trend_score, keywords, burst_score, "
-                "cross_platform_multiplier, external_trend_boost) "
-                "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING id",
+                "cross_platform_multiplier, external_trend_boost, growth_type) "
+                "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) RETURNING id",
                 item["category"],
                 item["locale"],
                 item["title"],
@@ -107,6 +108,7 @@ async def _save_individually(
                 item.get("burst_score", 0.0),
                 item.get("cross_platform_multiplier", 1.0),
                 item.get("external_trend_boost", 1.0),
+                item.get("growth_type", "unknown"),
             )
 
             articles: list[dict[str, Any]] = item.get("articles", [])

--- a/backend/processor/stages/score.py
+++ b/backend/processor/stages/score.py
@@ -17,6 +17,10 @@ from backend.processor.algorithms.burst import (
 )
 from backend.processor.algorithms.cross_platform import verify_cross_platform
 from backend.processor.algorithms.external_trends import verify_external_trends
+from backend.processor.algorithms.growth_classifier import (
+    VelocityWindow,
+    classify_growth_type,
+)
 from backend.processor.shared.score_calculator import (
     ScoreInput,
     ScoreResult,
@@ -111,6 +115,36 @@ def compute_early_trend_score(articles: list[dict[str, Any]]) -> float:
     return score
 
 
+def _build_velocity_windows(
+    articles: list[dict[str, Any]],
+    window_hours: int = 12,
+    num_windows: int = 3,
+    now: datetime | None = None,
+) -> list[VelocityWindow]:
+    """Build 12h velocity windows (newest → oldest) for growth classification."""
+    if now is None:
+        now = datetime.now(tz=timezone.utc)
+    buckets = [0] * num_windows
+    for a in articles:
+        pt = _parse_article_time(a)
+        if pt is None:
+            continue
+        hours_ago = (now - pt).total_seconds() / 3600
+        if hours_ago < 0:
+            continue
+        idx = int(hours_ago // window_hours)
+        if 0 <= idx < num_windows:
+            buckets[idx] += 1
+    return [
+        VelocityWindow(
+            window_start_hours_ago=i * window_hours,
+            window_end_hours_ago=(i + 1) * window_hours,
+            article_count=buckets[i],
+        )
+        for i in range(num_windows)
+    ]
+
+
 def _build_burst_series(articles: list[dict[str, Any]]) -> list[TimeSeriesPoint]:
     """Build a time series from article publish times for burst detection."""
     from collections import Counter
@@ -190,6 +224,9 @@ async def stage_score(
                 )
             early_velocity = _compute_momentum_velocity(articles)
 
+            velocity_windows = _build_velocity_windows(articles)
+            classified_growth = classify_growth_type(velocity_windows).value
+
             score_input = ScoreInput(
                 published_at=pub_time,
                 category=rep_article.get("category", "default"),
@@ -240,7 +277,11 @@ async def stage_score(
                     "locale": rep_article.get("locale", "ko"),
                     "keywords": unique_keywords,
                     "burst_score": burst_result.score,
-                    "growth_type": burst_result.growth_type,
+                    "growth_type": (
+                        classified_growth
+                        if classified_growth != "unknown"
+                        else burst_result.growth_type
+                    ),
                 }
             )
         except Exception as exc:

--- a/tests/test_growth_type_flow.py
+++ b/tests/test_growth_type_flow.py
@@ -1,0 +1,106 @@
+"""Tests for growth_type classification wired into stage_score."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from backend.processor.stages.score import _build_velocity_windows
+
+
+def _article(hours_ago: float) -> dict:
+    return {"publish_time": datetime.now(tz=timezone.utc) - timedelta(hours=hours_ago)}
+
+
+class TestBuildVelocityWindows:
+    def test_buckets_articles_by_12h_windows(self) -> None:
+        articles = [
+            _article(1),  # window 0
+            _article(2),  # window 0
+            _article(15),  # window 1
+            _article(30),  # window 2
+        ]
+        windows = _build_velocity_windows(articles)
+
+        assert len(windows) == 3
+        assert windows[0].article_count == 2
+        assert windows[1].article_count == 1
+        assert windows[2].article_count == 1
+        assert windows[0].window_start_hours_ago == 0
+        assert windows[0].window_end_hours_ago == 12
+
+    def test_empty_articles_returns_zero_buckets(self) -> None:
+        windows = _build_velocity_windows([])
+        assert [w.article_count for w in windows] == [0, 0, 0]
+
+    def test_articles_beyond_window_ignored(self) -> None:
+        articles = [_article(100)]  # outside 36h range
+        windows = _build_velocity_windows(articles)
+        assert all(w.article_count == 0 for w in windows)
+
+
+class TestClassifyGrowthIntegration:
+    def test_spike_pattern_detected(self) -> None:
+        from backend.processor.algorithms.growth_classifier import classify_growth_type
+
+        # 10 recent + 1 mid → spike
+        articles = [_article(2)] * 10 + [_article(15)]
+        windows = _build_velocity_windows(articles)
+        assert classify_growth_type(windows).value == "spike"
+
+    def test_growth_pattern_detected(self) -> None:
+        from backend.processor.algorithms.growth_classifier import classify_growth_type
+
+        # 12 recent, 10 mid, 8 old → growth (recent ≥ 1.2*mid, mid ≥ 1.1*old)
+        articles = [_article(2)] * 12 + [_article(15)] * 10 + [_article(28)] * 8
+        windows = _build_velocity_windows(articles)
+        assert classify_growth_type(windows).value == "growth"
+
+    def test_flat_pattern_unknown(self) -> None:
+        from backend.processor.algorithms.growth_classifier import classify_growth_type
+
+        articles = [_article(2)] * 5 + [_article(15)] * 5 + [_article(28)] * 5
+        windows = _build_velocity_windows(articles)
+        assert classify_growth_type(windows).value == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_stage_save_persists_classified_growth_type() -> None:
+    """End-to-end: a cluster with growth_type='spike' reaches the INSERT statement."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from backend.processor.stages import save as save_stage
+
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=[{"id": "gid-1"}])
+    conn.executemany = AsyncMock()
+    tx = MagicMock()
+    tx.__aenter__ = AsyncMock(return_value=None)
+    tx.__aexit__ = AsyncMock(return_value=None)
+    conn.transaction = MagicMock(return_value=tx)
+    acquire_cm = MagicMock()
+    acquire_cm.__aenter__ = AsyncMock(return_value=conn)
+    acquire_cm.__aexit__ = AsyncMock(return_value=None)
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=acquire_cm)
+
+    cluster = {
+        "category": "it",
+        "locale": "ko",
+        "title": "t",
+        "summary": "s",
+        "score": 50.0,
+        "early_trend_score": 0.4,
+        "keywords": ["a"],
+        "burst_score": 0.3,
+        "cross_platform_multiplier": 1.0,
+        "external_trend_boost": 1.0,
+        "growth_type": "spike",
+        "articles": [],
+    }
+    with patch.object(save_stage, "publish", AsyncMock()):
+        await save_stage.stage_save([cluster], pool)
+
+    sql, *args = conn.fetch.await_args.args
+    assert "growth_type" in sql
+    assert args[10] == ["spike"]

--- a/tests/test_score_multipliers_persist.py
+++ b/tests/test_score_multipliers_persist.py
@@ -12,6 +12,7 @@ def _make_cluster(
     *,
     cross_platform_multiplier: float = 1.25,
     external_trend_boost: float = 1.1,
+    growth_type: str = "spike",
 ) -> dict:
     return {
         "category": "it",
@@ -24,6 +25,7 @@ def _make_cluster(
         "burst_score": 0.6,
         "cross_platform_multiplier": cross_platform_multiplier,
         "external_trend_boost": external_trend_boost,
+        "growth_type": growth_type,
         "articles": [{"url_hash": "h1"}],
     }
 
@@ -55,9 +57,11 @@ class TestStageSaveMultipliers:
         sql, *args = conn.fetch.await_args.args
         assert "cross_platform_multiplier" in sql
         assert "external_trend_boost" in sql
-        # args positions 8,9 correspond to $9,$10 = multiplier/boost lists
+        assert "growth_type" in sql
+        # args positions 8,9,10 correspond to $9,$10,$11 = multiplier/boost/growth_type lists
         assert args[8] == [1.25]
         assert args[9] == [1.1]
+        assert args[10] == ["spike"]
 
     @pytest.mark.asyncio
     async def test_fallback_insert_includes_multipliers(self) -> None:
@@ -73,9 +77,11 @@ class TestStageSaveMultipliers:
         sql, *args = pool.fetchval.await_args.args
         assert "cross_platform_multiplier" in sql
         assert "external_trend_boost" in sql
-        # ($1..$10) = category, locale, title, summary, score, early, keywords, burst, mult, boost
+        assert "growth_type" in sql
+        # $1..$11 = category, locale, title, summary, score, early, kw, burst, mult, boost, growth
         assert args[8] == 0.9
         assert args[9] == 1.2
+        assert args[10] == "spike"
 
     @pytest.mark.asyncio
     async def test_missing_keys_default_to_one(self) -> None:
@@ -87,9 +93,11 @@ class TestStageSaveMultipliers:
         cluster = _make_cluster()
         cluster.pop("cross_platform_multiplier")
         cluster.pop("external_trend_boost")
+        cluster.pop("growth_type")
 
         await save_stage._save_individually([cluster], pool)
 
         args = pool.fetchval.await_args.args
+        assert args[-3] == 1.0
         assert args[-2] == 1.0
-        assert args[-1] == 1.0
+        assert args[-1] == "unknown"


### PR DESCRIPTION
## Summary
- `classify_growth_type` 호출 0건 문제 해결 — stage_score에서 12h×3 velocity 윈도우 구축 후 분류 결과를 cluster dict에 포함
- `stage_save` batch/fallback INSERT 모두 `growth_type` 컬럼 추가
- 마이그레이션 023: `news_group.growth_type TEXT DEFAULT 'unknown'`

## Test plan
- [x] pytest tests/test_growth_type_flow.py (7 passed)
- [x] pytest tests/test_score_multipliers_persist.py (3 passed)
- [x] 통합 pytest --cov: 1181 passed / 76.96%

Closes #258