### PR TITLE
Docs: LTR ranking 미연결 명시 (Wave C)

### DIFF
--- a/backend/processor/algorithms/ranking.py
+++ b/backend/processor/algorithms/ranking.py
@@ -2,6 +2,9 @@
 
 Falls back to rule-based ``score_calculator.calculate_score()`` when the
 trained model is unavailable or prediction fails.
+
+NOTE (2026-04-14): 미연결 모듈 — 향후 ML 파이프라인 도입 시 ``stages/score.py``에서
+``ltr_score_or_fallback`` 호출 예정. 현재는 score_calculator 기반 룰 스코어링만 운영.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
ranking.py docstring에 미연결 상태 1줄 명시. Closes #262