### PR TITLE
fix: 사용자 트래킹 이벤트 URL mismatch (404 → 201)

### DIFF
--- a/frontend/src/lib/tracker.test.ts
+++ b/frontend/src/lib/tracker.test.ts
@@ -41,6 +41,7 @@ describe('Tracker', () => {
 
 		expect(globalThis.fetch).toHaveBeenCalledTimes(1);
 		const callArgs = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+		expect(callArgs[0]).toMatch(/\/events\/batch$/);
 		const body = JSON.parse(callArgs[1].body);
 		expect(body.events).toHaveLength(2);
 		expect(body.events[0].event_type).toBe('click');

--- a/frontend/src/lib/tracker.ts
+++ b/frontend/src/lib/tracker.ts
@@ -1,6 +1,6 @@
 /**
  * Behavior event tracker.
- * Batches events and sends them to /api/v1/events.
+ * Batches events and sends them to /api/v1/events/batch.
  * RULE 01: No hardcoded secrets.
  * RULE 06: try/catch on all async.
  */
@@ -41,7 +41,7 @@ export async function flush(): Promise<void> {
 			headers['Authorization'] = `Bearer ${token}`;
 		}
 
-		await fetch(`${API_BASE}/events`, {
+		await fetch(`${API_BASE}/events/batch`, {
 			method: 'POST',
 			headers,
 			body: JSON.stringify({ events: batch })


### PR DESCRIPTION
## Summary
- /events → /events/batch URL 수정
- 회귀 방지 테스트 추가

## Impact
모든 trackEvent() 호출이 silent 404였음 → 개인화 behavior log 데이터 0건 누적.

Closes #276