### PR TITLE
Fix: 온보딩 엔드포인트 정합 수정

### DIFF
--- a/frontend/src/routes/onboarding/+page.svelte
+++ b/frontend/src/routes/onboarding/+page.svelte
@@ -115,11 +115,21 @@
 		if (isSubmitting) return;
 		isSubmitting = true;
 		try {
-			await apiRequest('/personalization/profile', {
+			const categoryWeights: Record<string, number> = {};
+			for (const key of selectedInterests) categoryWeights[key] = 2.0;
+
+			await apiRequest('/settings', {
 				method: 'PUT',
 				body: {
 					role: selectedRole,
-					interests: Array.from(selectedInterests),
+					category_weights: categoryWeights,
+				},
+			});
+
+			await apiRequest('/personalization', {
+				method: 'PUT',
+				body: {
+					category_weights: categoryWeights,
 					locale_ratio: localeRatio,
 				},
 			});
@@ -133,8 +143,14 @@
 
 			// Step 4: save notification settings (best-effort)
 			try {
-				await apiRequest('/notifications/settings', { method: 'POST', body: { type: 'surge_alert', enabled: notifSurge } });
-				await apiRequest('/notifications/settings', { method: 'POST', body: { type: 'weekly_digest', enabled: notifWeekly } });
+				await apiRequest('/notifications/settings', {
+					method: 'PUT',
+					body: { type: 'surge_alert', channel: 'email', is_enabled: notifSurge },
+				});
+				await apiRequest('/notifications/settings', {
+					method: 'PUT',
+					body: { type: 'weekly_digest', channel: 'email', is_enabled: notifWeekly },
+				});
 			} catch { /* ignore */ }
 
 			await authStore.fetchUser();


### PR DESCRIPTION
## Summary
- N14: PUT /personalization/profile(404) → PUT /settings(role+category_weights) + PUT /personalization(locale_ratio) 분리 호출
- N15: /notifications/settings POST → PUT, body shape {type, channel:'email', is_enabled}로 정렬

## Context
5차 감사 P0. 신규 가입 온보딩 완료 시 전부 실패하던 P0 기능 파손 복구.

Fix: #284