### PR TITLE
Fix: svelte-check 9건 제로화

### DIFF
--- a/frontend/src/components/StatCard.svelte
+++ b/frontend/src/components/StatCard.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
-	import type { Component } from 'svelte';
-
 	interface Props {
-		icon: Component;
+		// lucide-svelte icons are Svelte 4 legacy components; use loose type
+		icon: any;
 		iconColor?: string;
 		label: string;
 		value: string | number;

--- a/frontend/src/lib/api/types.test.ts
+++ b/frontend/src/lib/api/types.test.ts
@@ -21,7 +21,8 @@ describe('API Types', () => {
 			keywords: ['ai', 'ml'],
 			created_at: '2024-01-01T00:00:00Z',
 			article_count: 5,
-			direction: 'steady'
+			direction: 'steady',
+			status: 'stable'
 		};
 		expect(trend.id).toBe('1');
 		expect(trend.keywords).toHaveLength(2);

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -306,6 +306,9 @@ export interface RegionalTrendEntry {
 export interface RegionalTrendResponse {
 	entries: RegionalTrendEntry[];
 	total_locales: number;
+}
+
+// ---------------------------------------------------------------------------
 // Keyword Graph types
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/lib/components/KeywordGraph.svelte
+++ b/frontend/src/lib/components/KeywordGraph.svelte
@@ -139,32 +139,34 @@
 		hoveredNode = null;
 	}
 
-	onMount(async () => {
-		try {
-			const data = await apiRequest<KeywordGraphResponse>(
-				`/trends/${groupId}/keywords/graph`
-			);
-			if (data.nodes.length > 0) {
-				nodes = initPositions(data.nodes);
-				edges = data.edges;
-				let frameCount = 0;
-				const MAX_FRAMES = 120;
-				function limitedTick(): void {
-					frameCount++;
-					tick();
-					if (frameCount < MAX_FRAMES) {
-						animFrame = requestAnimationFrame(limitedTick);
+	onMount(() => {
+		void (async () => {
+			try {
+				const data = await apiRequest<KeywordGraphResponse>(
+					`/trends/${groupId}/keywords/graph`
+				);
+				if (data.nodes.length > 0) {
+					nodes = initPositions(data.nodes);
+					edges = data.edges;
+					let frameCount = 0;
+					const MAX_FRAMES = 120;
+					function limitedTick(): void {
+						frameCount++;
+						tick();
+						if (frameCount < MAX_FRAMES) {
+							animFrame = requestAnimationFrame(limitedTick);
+						}
 					}
+					animFrame = requestAnimationFrame(limitedTick);
 				}
-				animFrame = requestAnimationFrame(limitedTick);
+			} catch (e) {
+				if (!(e instanceof ApiRequestError)) {
+					hasError = true;
+				}
+			} finally {
+				isLoading = false;
 			}
-		} catch (e) {
-			if (!(e instanceof ApiRequestError)) {
-				hasError = true;
-			}
-		} finally {
-			isLoading = false;
-		}
+		})();
 
 		return () => {
 			if (animFrame !== null) cancelAnimationFrame(animFrame);

--- a/frontend/src/lib/components/TrendMap.svelte
+++ b/frontend/src/lib/components/TrendMap.svelte
@@ -112,32 +112,32 @@
 		animFrame = requestAnimationFrame(tick);
 	}
 
-	onMount(async () => {
-		try {
-			const data = await apiRequest<RelatedTrendsResponse>(
-				`/trends/${trendId}/related`
-			);
-			nodes = initPositions(data.nodes);
-			edges = data.edges;
-			// Run simulation for a limited number of frames
-			let frameCount = 0;
-			const MAX_FRAMES = 120;
-			function limitedTick(): void {
-				frameCount++;
-				tick();
-				if (frameCount < MAX_FRAMES) {
-					animFrame = requestAnimationFrame(limitedTick);
+	onMount(() => {
+		void (async () => {
+			try {
+				const data = await apiRequest<RelatedTrendsResponse>(
+					`/trends/${trendId}/related`
+				);
+				nodes = initPositions(data.nodes);
+				edges = data.edges;
+				let frameCount = 0;
+				const MAX_FRAMES = 120;
+				function limitedTick(): void {
+					frameCount++;
+					tick();
+					if (frameCount < MAX_FRAMES) {
+						animFrame = requestAnimationFrame(limitedTick);
+					}
 				}
+				animFrame = requestAnimationFrame(limitedTick);
+			} catch (e) {
+				if (!(e instanceof ApiRequestError)) {
+					hasError = true;
+				}
+			} finally {
+				isLoading = false;
 			}
-			animFrame = requestAnimationFrame(limitedTick);
-		} catch (e) {
-			if (!(e instanceof ApiRequestError)) {
-				hasError = true;
-			}
-			// On ApiRequestError (e.g. 404 no related trends) just show empty state
-		} finally {
-			isLoading = false;
-		}
+		})();
 
 		return () => {
 			if (animFrame !== null) cancelAnimationFrame(animFrame);

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -100,7 +100,7 @@
 				apiRequest<NewsListResponse>('/news?limit=5'),
 				apiRequest<TrendListResponse>('/trends/early?limit=5').catch((e) => {
 					if (e instanceof ApiRequestError && (e.errorCode === 'E0031' || e.status === 401)) {
-						return { items: [] } as TrendListResponse;
+						return { items: [], next_cursor: null, total: 0 } as TrendListResponse;
 					}
 					throw e;
 				}),


### PR DESCRIPTION
## Summary
- types.ts 구문 오류 + TrendItem status 누락 + onMount Promise 반환 2건 + TrendListResponse cast + lucide 아이콘 타입 4건

## Result
svelte-check 4041 파일 0 ERRORS (기존 9건 → 0건)

Fix: #286