### PR TITLE
Fix: 트렌드 제목 키워드 나열 스타일 폴백 축소

### DIFF
--- a/backend/processor/stages/score.py
+++ b/backend/processor/stages/score.py
@@ -246,12 +246,19 @@ async def stage_score(
                         keyword_counter[kw] += 1
             unique_keywords = [kw for kw, _ in keyword_counter.most_common(20)]
 
-            # Group title: prefer rep article's original title
-            raw_title = rep_article.get("title", "")
+            # Group title: pick the longest non-empty article title across the cluster.
+            # Falling back to a keyword join (" · ") produces keyword-stream-looking
+            # titles, so only use that when no article in the cluster has a usable title.
+            candidate_titles = [(a.get("title") or "").strip() for a in articles]
+            candidate_titles = [t for t in candidate_titles if len(t) >= 4]
+            candidate_titles.sort(key=len, reverse=True)
+            raw_title = candidate_titles[0] if candidate_titles else ""
             if raw_title:
                 group_title = raw_title if len(raw_title) <= 50 else raw_title[:45] + "…"
-            else:
+            elif unique_keywords:
                 group_title = " · ".join(unique_keywords[:3])
+            else:
+                group_title = "Untitled"
 
             early_score = compute_early_trend_score(articles)
             cross_platform_multiplier = verify_cross_platform(articles)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -246,6 +246,56 @@ class TestStageScore:
         assert 0.0 <= result[0]["early_trend_score"] <= 1.0
         assert "burst_score" in result[0]
 
+    async def test_group_title_prefers_longest_article_title(self) -> None:
+        short_article = _make_article(url="https://x.com/1", url_hash="h1", title="AI")
+        short_article["keywords"] = ["ai", "chip"]
+        long_article = _make_article(
+            url="https://x.com/2",
+            url_hash="h2",
+            title="엔비디아 AI 반도체 호조로 주가 급등",
+        )
+        long_article["keywords"] = ["ai", "chip"]
+
+        item = ClusterItem(
+            item_id="abc123",
+            text="Test",
+            keywords={"ai", "chip"},
+            published_at=datetime.now(tz=timezone.utc),
+            source_type="test",
+        )
+        cluster = Cluster(cluster_id="t1", representative=item, members=[])
+        cluster._articles = [short_article, long_article]  # type: ignore[attr-defined]
+
+        with patch(
+            "backend.processor.shared.config_loader.get_setting",
+            new_callable=AsyncMock,
+            return_value=25.0,
+        ):
+            result = await _stage_score([cluster], self._mock_pool())
+        assert result[0]["title"] == "엔비디아 AI 반도체 호조로 주가 급등"
+
+    async def test_group_title_falls_back_to_keywords_only_when_no_titles(self) -> None:
+        untitled = _make_article(title="")
+        untitled["keywords"] = ["ai", "chip", "nvidia"]
+
+        item = ClusterItem(
+            item_id="abc123",
+            text="Test",
+            keywords={"ai"},
+            published_at=datetime.now(tz=timezone.utc),
+            source_type="test",
+        )
+        cluster = Cluster(cluster_id="t2", representative=item, members=[])
+        cluster._articles = [untitled]  # type: ignore[attr-defined]
+
+        with patch(
+            "backend.processor.shared.config_loader.get_setting",
+            new_callable=AsyncMock,
+            return_value=25.0,
+        ):
+            result = await _stage_score([cluster], self._mock_pool())
+        assert " · " in result[0]["title"]
+
 
 class TestStageWarmCache:
     async def test_warms_cache_for_items(self) -> None:


### PR DESCRIPTION
## Summary
클러스터의 `articles[0]` 제목이 비면 바로 키워드 ` · ` 조합으로 떨어지던 폴백을, 클러스터 전체에서 길이 4 이상 비어있지 않은 제목 중 최장을 우선 선택하도록 변경.

## Test plan
- [x] test_pipeline.py TestStageScore: 최장 제목 선택 + 제목 전무 시 키워드 폴백 2 케이스 추가
- [ ] 수동: 배포 후 홈/트렌드 목록에서 '키워드 · 키워드' 스타일 제목이 사라졌는지 확인 (기존 저장분은 다음 수집 사이클 전까지 그대로 보일 수 있음)

Fix: #292