### PR TITLE
Hotfix: 클러스터 제목 .txt 마커 제거 + bigram 자기반복 스킵

### DIFF
--- a/backend/processor/shared/keyword_extractor.py
+++ b/backend/processor/shared/keyword_extractor.py
@@ -339,6 +339,8 @@ def _extract_bigrams(
     """
     bigrams: Counter[str] = Counter()
     for i in range(len(tokens) - 1):
+        if tokens[i] == tokens[i + 1]:
+            continue
         bigram = f"{tokens[i]}_{tokens[i + 1]}"
         bigrams[bigram] += 1
     return Counter({b: c for b, c in bigrams.items() if c >= min_freq})

--- a/backend/processor/shared/text_normalizer.py
+++ b/backend/processor/shared/text_normalizer.py
@@ -93,4 +93,6 @@ def normalize_title(title: str) -> str:
     # Remove trailing comment/view counts: [1162], (384), 숫자만
     cleaned = re.sub(r"[\s]*[\[(]\d+[\])]\s*$", "", cleaned)
     cleaned = re.sub(r"\s+\d+\s*$", "", cleaned)
+    # Remove trailing file-extension / format markers like [.txt], [.html]
+    cleaned = re.sub(r"\s*[\[(]\.[a-z0-9]{1,6}[\])]\s*$", "", cleaned, flags=re.IGNORECASE)
     return cleaned.strip()

--- a/backend/processor/stages/normalize.py
+++ b/backend/processor/stages/normalize.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import structlog
 
-from backend.processor.shared.text_normalizer import normalize_text
+from backend.processor.shared.text_normalizer import normalize_text, normalize_title
 
 logger = structlog.get_logger(__name__)
 
@@ -16,7 +16,7 @@ def stage_normalize(articles: list[dict[str, Any]]) -> list[dict[str, Any]]:
     result: list[dict[str, Any]] = []
     for article in articles:
         try:
-            article["title"] = normalize_text(article.get("title", ""))
+            article["title"] = normalize_title(article.get("title", ""))
             article["body"] = normalize_text(article.get("body", ""))
             if article["title"]:
                 result.append(article)


### PR DESCRIPTION
## Summary
develop #301 → main hotfix.

- `normalize_title`: 말미 `[.txt]`/`(.HTML)` 파일 확장자 마커 제거
- `stage_normalize`: 제목에 `normalize_title` 사용
- `_extract_bigrams`: 연속 동일 토큰 bigram 스킵

## Test plan
- [x] pytest 1180 passed (develop)